### PR TITLE
update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,38 @@
-on: create
-
-name: Release
+name: release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+  pull_request:
+    types:
+      - labeled
 jobs:
   release:
-    name: Release GitHub Actions
+    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
-      # https://github.com/technote-space/release-github-actions
-      - uses: technote-space/release-github-actions@v6
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      # Bump version on merging Pull Requests with specific labels.
+      # (bump:major,bump:minor,bump:patch)
+      - id: bumpr
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        uses: haya14busa/action-bumpr@v1
+
+      # Update corresponding major and minor tag.
+      # e.g. Update v1 and v1.2 when releasing v1.2.3
+      - uses: haya14busa/action-update-semver@v1
+        if: "!steps.bumpr.outputs.skip"
+        with:
+          tag: ${{ steps.bumpr.outputs.next_version }}
+  release-check:
+    if: github.event.action == 'labeled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: haya14busa/action-bumpr@v1

--- a/README.md
+++ b/README.md
@@ -15,14 +15,10 @@ A set of GitHub [Actions](https://docs.github.com/en/actions/creating-actions/ab
 
 ## Releasing
 
-Create and push a new tag with the format `v#.#.#`. The [release GHA](https://github.com/dbt-labs/actions/actions/workflows/release.yml) will create or update tags for the major and minor version (e.g. `v1`, `v1.1`). For example:
+Either:
 
-```
-git tag v1.2.3
-git push --tags
-```
-
-The [release GHA](https://github.com/dbt-labs/actions/actions/workflows/release.yml) will create or update the `v1` and `v1.2` tags to point to the same commit as `v1.2.3`.
+- Add a label to a PR (`bump:major`, `bump:minor`, `bump:patch`) to determine what part of the version to bump when merging PR. When the PR is merged, the [release GHA](https://github.com/dbt-labs/internal-actions/actions/workflows/release.yml) will create or update tags for the major and minor version (e.g. `v1`, `v1.1`).
+- Create a new tag with the format `v#.#.#`. The [release GHA](https://github.com/dbt-labs/internal-actions/actions/workflows/release.yml) will create or update tags for the major and minor version (e.g. `v1`, `v1.1`).
 
 ## Development
 


### PR DESCRIPTION
- automates creating git tags for PRs after they are merged based on a label on the PR
- maintains the existing release functionality if we want to cut a release without merging a PR (manually creating a git tag)