### PR TITLE
tweak the jira-transition workflow

### DIFF
--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -30,8 +30,11 @@ on:
         required: true
 
 jobs:
-  close-issue:
+  extract-id:
     runs-on: ubuntu-latest
+    if: startsWith(github.event.issue.title, format('[{0}-', ${{inputs.project_key}}))
+    outputs:
+      issueId: ${{ steps.extract.outputs.issueId }}
     steps:
       - name: Extract Jira issue ID from title
         id: extract
@@ -41,9 +44,11 @@ jobs:
           issueId=$(echo -n $TITLE | awk '{print $1}' | awk -F'[][]' '{print $2}')
           echo ::set-output name=issueId::$issueId
 
+  transition-issue:
+    runs-on: ubuntu-latest
+    needs: extract-id
+    steps:
       - name: Jira login
-        id: jira-login
-        if: startsWith(steps.extract.outputs.issueId, format('[{0}-', ${{inputs.project_key}}))
         uses: atlassian/gajira-login@master
         env:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
only attempt to transition in jira if the github issue has been mirrored to jira (example of a failure when the issue doesn't exist in jira https://github.com/dbt-labs/homebrew-dbt/runs/6033513150?check_suite_focus=true)