### PR TITLE
only set version when we find artifact for that version

### DIFF
--- a/.github/workflows/py-package-info.yml
+++ b/.github/workflows/py-package-info.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Test Valid Version
         run: |
           [ "${{ steps.without-version.outputs.name }}" != dbt-snowflake ] && exit 1
+          [ -z "${{ steps.without-version.outputs.version }}" ] && exit 1
           [ -z "${{ steps.without-version.outputs.source-url }}" ] && exit 1
           [ -z "${{ steps.without-version.outputs.source-checksum }}" ] && exit 1
           exit 0

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -47,6 +47,7 @@ def lookup_package(name, version=None):
                 for version_artifact in pkg_data['releases'][pypi_version]:
                     if version_artifact['packagetype'] == 'sdist':
                         artifact = version_artifact
+                        d['version'] = version
                         break
         if artifact is None:
             print("::warning::Could not find an exact version match for "
@@ -60,7 +61,6 @@ def lookup_package(name, version=None):
 
     if artifact:
         d['url'] = artifact['url']
-        d['version'] = version
         if 'digests' in artifact and 'sha256' in artifact['digests']:
             print(f"::debug::Using provided checksum for {name}")
             d['checksum'] = artifact['digests']['sha256']


### PR DESCRIPTION
when version is not specified as an action input, it returned no version instead of the latest version