### PR TITLE
GitHub Release Workflow for Automated Release

### DIFF
--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -100,7 +100,7 @@ jobs:
             exit 1
           fi
           isDraft=$(jq -r '.isDraft' <<< "$output")
-          if [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq false ]]
+          if [[ $isDraft == true ]] && [[ ${{ inputs.testing }} == false ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
             echo "::set-output name=exists::false"
@@ -192,7 +192,7 @@ jobs:
       - name: Set as draft release
         id: draft
         run: |
-          if [[ ${{ inputs.testing }} -eq true ]]
+          if [[ ${{ inputs.testing }} == true ]]
           then
             echo This is a draft release
             echo ::set-output name=draft::--draft

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -101,6 +101,7 @@ jobs:
             echo "::set-output name=exists::true"
             echo "::set-output name=draft_exists::false"
           elif [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq 'false' ]]
+          then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
             echo "::set-output name=exists::false"
             echo "::set-output name=draft_exists::true"

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -19,7 +19,9 @@
 #
 # Validation Checks
 #
-#  1. TODO:
+#  1. Checks if there is already a release for this tag/commit and if there is, skips the rest.
+#  2. If this release exists for this tag but a different commit, FAIL.
+#  3. If this commit has a release associated with it for a different version, FAIL.
 
 name: GitHub Release
 

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -42,7 +42,7 @@ on:
     outputs:
       tag: 
         description: The path to the changelog for this version
-        value: ${{ jobs.check-release-exists.outputs.exists }} ${{ jobs.audit-changelog.outputs.changelog_path }}
+        value: ${{ jobs.check-release-exists.outputs.tag }}
 
 
 permissions:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -166,12 +166,11 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
 
-      # TODO: should this havve the option of saving to a draft release when testing?
+      # TODO: should this have the option of saving to a draft release when testing?
       - name: Create GitHub Release
         run: |
           gh release create ${{ env.tag }} --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE
-          gh release upload ${{ env.tag }} ./dist/*.gz 
-          gh release upload ${{ env.tag }} ./dist/*.whl
+          gh release upload ${{ env.tag }} ./dist/*
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -56,7 +56,8 @@ jobs:
         run: |
             echo The last commit sha in the release: ${{ inputs.sha }}
             echo The release version number: ${{ inputs.version_number }}
-            echo Expected Changlog path: "${{ inputs.changelog_path }}"
+            echo Expected Changlog path: ${{ inputs.changelog_path }}
+            echo testing: ${{ inputs.testing }}
 
   check-release-exists:
     runs-on: ubuntu-latest

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -100,12 +100,12 @@ jobs:
             exit 1
           fi
           isDraft=$(jq -r '.isDraft' <<< "$output")
-          if [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} == "true" ]]
+          if [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq true ]]
           then
             echo Draft release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
             echo "::set-output name=exists::true"
             echo "::set-output name=draft_exists::false"
-          elif [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} == "false" ]]
+          elif [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq false ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
             echo "::set-output name=exists::false"
@@ -229,7 +229,7 @@ jobs:
       - name: Set as draft release
         id: draft
         run: |
-          if [[ ${{ inputs.testing }} == "true" ]]
+          if [[ ${{ inputs.testing }} == true ]]
           then
             echo This is a draft release
             echo ::set-output name=draft::--draft
@@ -238,7 +238,7 @@ jobs:
           fi
       
       - name: Publish a release that was previously a draft
-        if: ${{ inputs.testing }} == "false" && ${{ needs.check-release-exists.outputs.draft_exists }} == "true"
+        if: ${{ inputs.testing }} == 'false' && ${{ needs.check-release-exists.outputs.draft_exists }} == 'true'
         run: |
           gh release edit $TAG --draft=false
         env:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -39,7 +39,7 @@ on:
       testing: 
         required: true
         type: string
-    utputs:
+    outputs:
       tag: 
         description: The path to the changelog for this version
         value: ${{ jobs.check-release-exists.outputs.exists }} ${{ jobs.audit-changelog.outputs.changelog_path }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -81,7 +81,8 @@ jobs:
             exit 0
           fi
           commit=$(jq -r '.targetCommitish' <<< "$output")
-          if $commit != ${{ inputs.sha }} then
+          if [[ $commit != ${{ inputs.sha }} ]]
+          then
             echo Release for tag ${{ env.tag }} already exists for commit $commit!
             echo Cannot create a new release for commit ${{ inputs.sha }}.  Exiting.
             exit 1

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -17,6 +17,9 @@
 #
 # This workflow expects the artifacts to already be built and living in the artifact store of the workflow.
 #
+# Validation Checks
+#
+#  1. TODO:
 
 name: GitHub Release
 
@@ -33,6 +36,9 @@ on:
         description: Path to the changelog file for release notes
         required: true
         type: string
+      testing:
+        required: true
+        type: boolean
 
 permissions:
   contents: write

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -100,21 +100,15 @@ jobs:
             exit 1
           fi
           isDraft=$(jq -r '.isDraft' <<< "$output")
-          if [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq true ]]
-          then
-            echo Draft release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
-            echo "::set-output name=exists::true"
-            echo "::set-output name=draft_exists::false"
-          elif [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq false ]]
+          if [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq false ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
             echo "::set-output name=exists::false"
             echo "::set-output name=draft_exists::true"
-          else
-            echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
-            echo "::set-output name=exists::true"
-            echo "::set-output name=draft_exists::false"
           fi
+          echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
+          echo "::set-output name=exists::true"
+          echo "::set-output name=draft_exists::false"
 
           if [[ ${{ inputs.testing }} == "false" ]]
           then
@@ -238,7 +232,7 @@ jobs:
           fi
       
       - name: Publish a release that was previously a draft
-        if: ${{ inputs.testing }} == 'false' && ${{ needs.check-release-exists.outputs.draft_exists }} == 'true'
+        if: inputs.testing  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
         run: |
           gh release edit $TAG --draft=false
         env:
@@ -246,7 +240,7 @@ jobs:
           TAG: ${{ needs.check-release-exists.outputs.tag }}
 
       - name: Create New GitHub Release
-        if: ${{ needs.check-release-exists.outputs.draft_exists }} == 'false'
+        if: needs.check-release-exists.outputs.draft_exists == 'false'
         run: |
           gh release create $TAG ./dist/* --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
         env:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -62,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       exists: ${{ steps.release_check.outputs.exists }}
+      draft_exists: ${{ steps.release_check.outputs.draft_exists }}
       tag: ${{ steps.set_tag.outputs.tag }}
 
     steps:
@@ -79,7 +80,7 @@ jobs:
       - name: Check if release exists for tag
         id: release_check
         run: |
-          output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json targetCommitish) 2>&1) || true
+          output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json isDraft,targetCommitish) 2>&1) || true
           if [[ "$output" == "release not found" ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} does not exist
@@ -93,8 +94,22 @@ jobs:
             echo Cannot create a new release for commit ${{ inputs.sha }}.  Exiting.
             exit 1
           fi
-          echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists
-          echo "::set-output name=exists::true"
+          isDraft=$(jq -r '.isDraft' <<< "$output")
+          if [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq 'true' ]]
+          then
+            echo Draft release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
+            echo "::set-output name=exists::true"
+            echo "::set-output name=draft_exists::false"
+          elif [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq 'false' ]]
+            echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
+            echo "::set-output name=exists::false"
+            echo "::set-output name=draft_exists::true"
+          else
+            echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
+            echo "::set-output name=exists::true"
+            echo "::set-output name=draft_exists::false"
+          fi
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -177,11 +192,19 @@ jobs:
           else
             echo This is not a draft release
           fi
+      
+      - name: Publish a release that was previously a draft
+        if: ${{ inputs.testing }} != 'true' && ${{ needs.check-release-exists.outputs.draft_exists }} == 'true'
+        run: |
+          gh release edit $TAG --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.check-release-exists.outputs.tag }}
 
-      - name: Create GitHub Release
+      - name: Create New GitHub Release
+        if: ${{ needs.check-release-exists.outputs.draft_exists }} == 'false'
         run: |
           gh release create $TAG ./dist/* --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.check-release-exists.outputs.tag }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -144,9 +144,14 @@ jobs:
           then
             echo eighth
           fi
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Log Job Outputs
+        run: |
+          echo exists: ${{ steps.release_check.outputs.exists }}
+          echo draft_exists: ${{ steps.release_check.outputs.draft_exists }}
+          echo tag: ${{ steps.set_tag.outputs.tag }}
 
   skip-github-release:
     runs-on: ubuntu-latest
@@ -229,7 +234,7 @@ jobs:
           fi
       
       - name: Publish a release that was previously a draft
-        if: ${{ inputs.testing }} != "true" && ${{ needs.check-release-exists.outputs.draft_exists }} == "true"
+        if: ${{ inputs.testing }} == "false" && ${{ needs.check-release-exists.outputs.draft_exists }} == "true"
         run: |
           gh release edit $TAG --draft=false
         env:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -173,7 +173,6 @@ jobs:
           gh release upload ${{ env.tag }} ./dist/*.gz 
           gh release upload ${{ env.tag }} ./dist/*.whl
 
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: ${{ github.event.repository.name }} ${{ env.tag }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -36,15 +36,17 @@ on:
         description: Path to the changelog file for release notes
         required: true
         type: string
-      testing:
+      testing: 
         required: true
         type: string
+    utputs:
+      tag: 
+        description: The path to the changelog for this version
+        value: ${{ jobs.check-release-exists.outputs.exists }} ${{ jobs.audit-changelog.outputs.changelog_path }}
+
 
 permissions:
   contents: write
-
-env:
-  tag: v${{ inputs.version_number }}
 
 jobs:
   log-inputs:
@@ -63,6 +65,10 @@ jobs:
       tag: ${{ steps.set_tag.outputs.tag }}
 
     steps:
+      - name: Generate Tag in Expected format
+        id: set_tag
+        run: echo "::set-output name=tag::v${{ inputs.version_number }}"
+
       - name: Check out the repository
         uses: actions/checkout@v3
       
@@ -73,21 +79,21 @@ jobs:
       - name: Check if release exists for tag
         id: release_check
         run: |
-          output=$((gh release view ${{ env.tag }} --json targetCommitish) 2>&1) || true
+          output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json targetCommitish) 2>&1) || true
           if [[ "$output" == "release not found" ]]
           then
-            echo Release for tag ${{ env.tag }} does not exist
+            echo Release for tag ${{ steps.set_tag.outputs.tag }} does not exist
             echo "::set-output name=exists::false"
             exit 0
           fi
           commit=$(jq -r '.targetCommitish' <<< "$output")
           if [[ $commit != ${{ inputs.sha }} ]]
           then
-            echo Release for tag ${{ env.tag }} already exists for commit $commit!
+            echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists for commit $commit!
             echo Cannot create a new release for commit ${{ inputs.sha }}.  Exiting.
             exit 1
           fi
-          echo Release for tag ${{ env.tag }} already exists
+          echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists
           echo "::set-output name=exists::true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,7 +105,7 @@ jobs:
 
     steps:
       - name: Tag Exists, Skip GitHub Release Job
-        run: echo A tag already exists for ${{ env.tag }} and commit, skipping release
+        run: echo A tag already exists for ${{ jobs.check-release-exists.outputs.tag }} and commit, skipping release
 
   audit-release-different-commit:
     runs-on: ubuntu-latest
@@ -129,12 +135,12 @@ jobs:
         if: steps.check_release_commit.outputs.id != ''
         run: |
           echo Tag "${{ steps.check_release_commit.outputs.tag_name}}" already exists for this commit!
-          echo Cannot create a new tag for "${{ env.tag }}" for the same commit.
+          echo Cannot create a new tag for "${{ jobs.check-release-exists.outputs.tag }}" for the same commit.
           exit 1
 
   github-release:
     runs-on: ubuntu-latest
-    needs: [audit-release-different-commit]
+    needs: [check-release-exists, audit-release-different-commit]
 
     steps:
       - name: Check out the repository
@@ -174,11 +180,12 @@ jobs:
 
       - name: Create GitHub Release
         run: |
-          gh release create ${{ env.tag }} ./dist/* --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
+          gh release create $TAG ./dist/* --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TITLE: ${{ github.event.repository.name }} ${{ env.tag }}
+          TAG: ${{ jobs.check-release-exists.outputs.tag }}
+          TITLE: ${{ github.event.repository.name }} ${{ jobs.check-release-exists.outputs.tag }}
           RELEASE_NOTES: ${{ inputs.changelog_path }}
           COMMIT: ${{ inputs.sha }}
           PRERELEASE: ${{ steps.release_type.outputs.prerelease}}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -38,7 +38,7 @@ on:
         type: string
       testing:
         required: true
-        type: boolean
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -96,12 +96,12 @@ jobs:
             exit 1
           fi
           isDraft=$(jq -r '.isDraft' <<< "$output")
-          if [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq 'true' ]]
+          if [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} == "true" ]]
           then
             echo Draft release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
             echo "::set-output name=exists::true"
             echo "::set-output name=draft_exists::false"
-          elif [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} -eq 'false' ]]
+          elif [[ $isDraft -eq true ]] && [[ ${{ inputs.testing }} == "false" ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
             echo "::set-output name=exists::false"
@@ -110,6 +110,39 @@ jobs:
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
             echo "::set-output name=exists::true"
             echo "::set-output name=draft_exists::false"
+          fi
+
+          if [[ ${{ inputs.testing }} == "false" ]]
+          then
+            echo first
+          fi
+          if [[ ${{ inputs.testing }} -eq "false" ]]
+          then
+            echo second
+          fi
+          if [[ ${{ inputs.testing }} == false ]]
+          then
+            echo third
+          fi
+          if [[ ${{ inputs.testing }} -eq false ]]
+          then
+            echo forth
+          fi
+          if [[ ${{ inputs.testing }} == "true" ]]
+          then
+            echo fifth
+          fi
+          if [[ ${{ inputs.testing }} -eq "true" ]]
+          then
+            echo sixth
+          fi
+          if [[ ${{ inputs.testing }} == true ]]
+          then
+            echo seventh
+          fi
+          if [[ ${{ inputs.testing }} -eq true ]]
+          then
+            echo eighth
           fi
 
         env:
@@ -187,7 +220,7 @@ jobs:
       - name: Set as draft release
         id: draft
         run: |
-          if [[ ${{ inputs.testing }} -eq "true" ]]
+          if [[ ${{ inputs.testing }} == "true" ]]
           then
             echo This is a draft release
             echo ::set-output name=draft::--draft
@@ -196,7 +229,7 @@ jobs:
           fi
       
       - name: Publish a release that was previously a draft
-        if: ${{ inputs.testing }} != 'true' && ${{ needs.check-release-exists.outputs.draft_exists }} == 'true'
+        if: ${{ inputs.testing }} != "true" && ${{ needs.check-release-exists.outputs.draft_exists }} == "true"
         run: |
           gh release edit $TAG --draft=false
         env:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Create GitHub Release
         run: |
-          gh release create ${{ env.tag }} --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
+          gh release create ${{ env.tag }} ./dist/* --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -182,10 +182,3 @@ jobs:
           COMMIT: ${{ inputs.sha }}
           PRERELEASE: ${{ steps.release_type.outputs.prerelease}}
           DRAFT: ${{ steps.draft.outputs.draft}}
-
-      - name: Attach artifacts to release
-        run: |
-          gh release upload ${{ env.tag }} ./dist/*
-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - name: Tag Exists, Skip GitHub Release Job
-        run: echo A tag already exists for ${{ jobs.check-release-exists.outputs.tag }} and commit, skipping release
+        run: echo A tag already exists for ${{ needs.check-release-exists.outputs.tag }} and commit, skipping release
 
   audit-release-different-commit:
     runs-on: ubuntu-latest
@@ -135,7 +135,7 @@ jobs:
         if: steps.check_release_commit.outputs.id != ''
         run: |
           echo Tag "${{ steps.check_release_commit.outputs.tag_name}}" already exists for this commit!
-          echo Cannot create a new tag for "${{ jobs.check-release-exists.outputs.tag }}" for the same commit.
+          echo Cannot create a new tag for "${{ needs.check-release-exists.outputs.tag }}" for the same commit.
           exit 1
 
   github-release:
@@ -184,8 +184,8 @@ jobs:
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ jobs.check-release-exists.outputs.tag }}
-          TITLE: ${{ github.event.repository.name }} ${{ jobs.check-release-exists.outputs.tag }}
+          TAG: ${{ needs.check-release-exists.outputs.tag }}
+          TITLE: ${{ github.event.repository.name }} ${{ needs.check-release-exists.outputs.tag }}
           RELEASE_NOTES: ${{ inputs.changelog_path }}
           COMMIT: ${{ inputs.sha }}
           PRERELEASE: ${{ steps.release_type.outputs.prerelease}}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -169,8 +169,11 @@ jobs:
       # TODO: should this havve the option of saving to a draft release when testing?
       - name: Create GitHub Release
         run: |
-          gh release create ${{ env.tag }} -title "$TITLE" -notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE
-          gh release upload ${{ env.tag }} ./dist/*.gz ./dist/*.whl
+          gh release create ${{ env.tag }} --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE
+          gh release upload ${{ env.tag }} ./dist/*.gz 
+          gh release upload ${{ env.tag }} ./dist/*.whl
+
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: ${{ github.event.repository.name }} ${{ env.tag }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -158,12 +158,16 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
 
+      # TODO: should this havve the option of saving to a draft release when testing?
       - name: Create GitHub Release
         run: |
-          gh release create ${{ env.tag }} -t "$TITLE" -F $RELEASE_NOTES --target $COMMIT ./dist/*.whl ./dist/*.gz $PRERELEASE
+          gh release create ${{ env.tag }} -title "$TITLE" -notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE
+          gh release upload ${{ env.tag }} ./dist/*.gz ./dist/*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: ${{ github.event.repository.name }} ${{ env.tag }}
           RELEASE_NOTES: ${{ inputs.changelog_path }}
           COMMIT: ${{ inputs.sha }}
           PRERELEASE: ${{ steps.release_type.outputs.prerelease}}
+
+

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -141,6 +141,10 @@ jobs:
     needs: [audit-release-different-commit]
 
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.sha }}
 
       - uses: actions/download-artifact@v3
         with:
@@ -161,14 +165,10 @@ jobs:
             echo This is not a prerelease
           fi
 
-      - name: Check out the repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.sha }}
-
       # TODO: should this have the option of saving to a draft release when testing?
       - name: Create GitHub Release
         run: |
+          ls -al
           gh release create ${{ env.tag }} --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE
           gh release upload ${{ env.tag }} ./dist/*
 

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -1,8 +1,5 @@
 # **what?**
-# If no release already exists for this commit and version, create the tag and release it to GitHub.
-# If a release already exists for this commit, skip creating the release but finish with a success.
-# If a release exists for this commit under a different tag, fail.
-# If the commit is already associated with a different release, fail.
+# Create a new release on GitHub and include any artifacts in the `/dist` directory of the GitHUb artifacts store.
 #
 # Inputs:
 #  sha: the commit to attach to this release
@@ -13,15 +10,16 @@
 # Reusable and consistent GitHub release process.
 #
 # **when?**
-# Call after the build process.
+# Call after a successful build.  Build artifacts should be ready to release and live in a dist/ directory.
 #
 # This workflow expects the artifacts to already be built and living in the artifact store of the workflow.
 #
 # Validation Checks
 #
-#  1. Checks if there is already a release for this tag/commit and if there is, skips the rest.
-#  2. If this release exists for this tag but a different commit, FAIL.
-#  3. If this commit has a release associated with it for a different version, FAIL.
+# 1. If no release already exists for this commit and version, create the tag and release it to GitHub.
+# 2. If a release already exists for this commit, skip creating the release but finish with a success.
+# 3. If a release exists for this commit under a different tag, fail.
+# 4. If the commit is already associated with a different release, fail.
 
 name: GitHub Release
 
@@ -90,7 +88,6 @@ jobs:
           fi
           echo Release for tag ${{ env.tag }} already exists
           echo "::set-output name=exists::true"
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -109,7 +106,6 @@ jobs:
     if: needs.check-release-exists.outputs.exists == 'false'
 
     steps:
-
       - name: Check if release already exists for commit
         uses: cardinalby/git-get-release-action@v1
         id: check_release_commit
@@ -126,7 +122,6 @@ jobs:
           echo steps.check_release_commit.outputs.tag_name ${{ steps.check_release_commit.outputs.tag_name}}
           echo steps.check_release_commit.outputs.target_commitish ${{ steps.check_release_commit.outputs.target_commitish}}
           echo steps.check_release_commit.outputs.prerelease ${{ steps.check_release_commit.outputs.prerelease}}
-
 
       # Since we already know a release for this tag does not exist, if we find anything it's for the wrong tag, exit
       - name: Check if the tag matches the version number
@@ -165,11 +160,20 @@ jobs:
             echo This is not a prerelease
           fi
 
-      # TODO: should this have the option of saving to a draft release when testing?
+      - name: Set as draft release
+        id: draft
+        run: |
+          if [[ ${{ inputs.testing }} -eq "true" ]]
+          then
+            echo This is a draft release
+            echo ::set-output name=draft::--draft
+          else
+            echo This is not a draft release
+          fi
+
       - name: Create GitHub Release
         run: |
-          ls -al
-          gh release create ${{ env.tag }} --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE
+          gh release create ${{ env.tag }} --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
           gh release upload ${{ env.tag }} ./dist/*
 
         env:
@@ -178,5 +182,6 @@ jobs:
           RELEASE_NOTES: ${{ inputs.changelog_path }}
           COMMIT: ${{ inputs.sha }}
           PRERELEASE: ${{ steps.release_type.outputs.prerelease}}
+          DRAFT: ${{ steps.draft.outputs.draft}}
 
 

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -1,0 +1,169 @@
+# **what?**
+# If no release already exists for this commit and version, create the tag and release it to GitHub.
+# If a release already exists for this commit, skip creating the release but finish with a success.
+# If a release exists for this commit under a different tag, fail.
+# If the commit is already associated with a different release, fail.
+#
+# Inputs:
+#  sha: the commit to attach to this release
+#  version_number: version number for the release (ex: 1.2.3rc2)
+#  file_uploads: Newline-delimited globs of paths to assets to upload for release
+#   
+# **why?**
+# Reusable and consistent GitHub release process.
+#
+# **when?**
+# Call after the build process.
+#
+# This workflow expects the artifacts to already be built and living in the artifact store of the workflow.
+#
+
+name: GitHub Release
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        required: true
+        type: string
+      version_number:
+        required: true
+        type: string
+      changelog_path:
+        description: Path to the changelog file for release notes
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  tag: v${{ inputs.version_number }}
+
+jobs:
+  log-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print variables
+        run: |
+            echo The last commit sha in the release: ${{ inputs.sha }}
+            echo The release version number: ${{ inputs.version_number }}
+            echo Expected Changlog path: "${{ inputs.changelog_path }}"
+
+  check-release-exists:
+    runs-on: ubuntu-latest
+    outputs:
+      exists: ${{ steps.release_check.outputs.exists }}
+      tag: ${{ steps.set_tag.outputs.tag }}
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+      
+      # When the GitHub CLI doesn't find a release for the given tag, it will exit 1 with a
+      # message of "release not found".  In our case, it's not an actual error, just a 
+      # confirmation that the release does not already exists so we can go ahead and create it.
+      # The `|| true` makes it so the step does not exit with a non-zero exit code
+      - name: Check if release exists for tag
+        id: release_check
+        run: |
+          output=$((gh release view ${{ env.tag }} --json targetCommitish) 2>&1) || true
+          if [[ "$output" == "release not found" ]]
+          then
+            echo Release for tag ${{ env.tag }} does not exist
+            echo "::set-output name=exists::false"
+            exit 0
+          fi
+          commit=$(jq -r '.targetCommitish' <<< "$output")
+          if $commit != ${{ inputs.sha }} then
+            echo Release for tag ${{ env.tag }} already exists for commit $commit!
+            echo Cannot create a new release for commit ${{ inputs.sha }}.  Exiting.
+            exit 1
+          fi
+          echo Release for tag ${{ env.tag }} already exists
+          echo "::set-output name=exists::true"
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  skip-github-release:
+    runs-on: ubuntu-latest
+    needs: [check-release-exists]
+    if: needs.check-release-exists.outputs.exists == 'true'
+
+    steps:
+      - name: Tag Exists, Skip GitHub Release Job
+        run: echo A tag already exists for ${{ env.tag }} and commit, skipping release
+
+  audit-release-different-commit:
+    runs-on: ubuntu-latest
+    needs: [check-release-exists]
+    if: needs.check-release-exists.outputs.exists == 'false'
+
+    steps:
+
+      - name: Check if release already exists for commit
+        uses: cardinalby/git-get-release-action@v1
+        id: check_release_commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitSha: ${{inputs.sha}}
+          doNotFailIfNotFound: true # returns blank outputs when not found instead of error
+          searchLimit: 15 # Since we only care about recent releases, speed up the process
+
+      - name: Print Release Details
+        run: |
+          echo steps.check_release_commit.outputs.id ${{ steps.check_release_commit.outputs.id}}
+          echo steps.check_release_commit.outputs.tag_name ${{ steps.check_release_commit.outputs.tag_name}}
+          echo steps.check_release_commit.outputs.target_commitish ${{ steps.check_release_commit.outputs.target_commitish}}
+          echo steps.check_release_commit.outputs.prerelease ${{ steps.check_release_commit.outputs.prerelease}}
+
+
+      # Since we already know a release for this tag does not exist, if we find anything it's for the wrong tag, exit
+      - name: Check if the tag matches the version number
+        if: steps.check_release_commit.outputs.id != ''
+        run: |
+          echo Tag "${{ steps.check_release_commit.outputs.tag_name}}" already exists for this commit!
+          echo Cannot create a new tag for "${{ env.tag }}" for the same commit.
+          exit 1
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs: [audit-release-different-commit]
+
+    steps:
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: '.'
+
+      - name: Display structure of all downloaded files
+        run: ls -R
+
+      - name: Set release type
+        id: release_type
+        run: |
+          if ${{ contains(inputs.version_number, 'rc') ||  contains(inputs.version_number, 'b') }}
+          then
+            echo This is a prerelease
+            echo ::set-output name=prerelease::--prerelease
+          else
+            echo This is not a prerelease
+          fi
+
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Create GitHub Release
+        run: |
+          gh release create ${{ env.tag }} -t "$TITLE" -F $RELEASE_NOTES --target $COMMIT ./dist/*.whl ./dist/*.gz $PRERELEASE
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ github.event.repository.name }} ${{ env.tag }}
+          RELEASE_NOTES: ${{ inputs.changelog_path }}
+          COMMIT: ${{ inputs.sha }}
+          PRERELEASE: ${{ steps.release_type.outputs.prerelease}}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -78,6 +78,9 @@ jobs:
       # message of "release not found".  In our case, it's not an actual error, just a 
       # confirmation that the release does not already exists so we can go ahead and create it.
       # The `|| true` makes it so the step does not exit with a non-zero exit code
+      # Also check if the release already exists is draft state.  If it does, and we are not
+      # testing then we can publish that draft as is.  If it's in draft and we are testing, skip the
+      # release.
       - name: Check if release exists for tag
         id: release_check
         run: |
@@ -86,6 +89,7 @@ jobs:
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} does not exist
             echo "::set-output name=exists::false"
+            echo "::set-output name=draft_exists::false"
             exit 0
           fi
           commit=$(jq -r '.targetCommitish' <<< "$output")

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -174,7 +174,6 @@ jobs:
       - name: Create GitHub Release
         run: |
           gh release create ${{ env.tag }} --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
-          gh release upload ${{ env.tag }} ./dist/*
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -184,4 +183,9 @@ jobs:
           PRERELEASE: ${{ steps.release_type.outputs.prerelease}}
           DRAFT: ${{ steps.draft.outputs.draft}}
 
+      - name: Attach artifacts to release
+        run: |
+          gh release upload ${{ env.tag }} ./dist/*
 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -105,43 +105,12 @@ jobs:
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
             echo "::set-output name=exists::false"
             echo "::set-output name=draft_exists::true"
+            exit 0
           fi
           echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
           echo "::set-output name=exists::true"
           echo "::set-output name=draft_exists::false"
 
-          if [[ ${{ inputs.testing }} == "false" ]]
-          then
-            echo first
-          fi
-          if [[ ${{ inputs.testing }} -eq "false" ]]
-          then
-            echo second
-          fi
-          if [[ ${{ inputs.testing }} == false ]]
-          then
-            echo third
-          fi
-          if [[ ${{ inputs.testing }} -eq false ]]
-          then
-            echo forth
-          fi
-          if [[ ${{ inputs.testing }} == "true" ]]
-          then
-            echo fifth
-          fi
-          if [[ ${{ inputs.testing }} -eq "true" ]]
-          then
-            echo sixth
-          fi
-          if [[ ${{ inputs.testing }} == true ]]
-          then
-            echo seventh
-          fi
-          if [[ ${{ inputs.testing }} -eq true ]]
-          then
-            echo eighth
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
@@ -223,7 +192,7 @@ jobs:
       - name: Set as draft release
         id: draft
         run: |
-          if [[ ${{ inputs.testing }} == true ]]
+          if [[ ${{ inputs.testing }} -eq true ]]
           then
             echo This is a draft release
             echo ::set-output name=draft::--draft


### PR DESCRIPTION
Resolves: #16 

Purpose: Release to GitHUb after building release artifacts and changelog for release notes
- If a tag exists for another commit, fail.
- If a different tag exists for this commit, fail.
- If this is a `testing` run, mark the release as a draft.
- If a draft release exists for this commit/tag and we are not `testing` then publish the release.  

