### PR TITLE
Version Bump and Changelog Generation for Automated Release

### DIFF
--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -301,6 +301,7 @@ jobs:
       
       - name: Merge branch into target branch
         run: |
+          git fetch origin
           git checkout ${{ inputs.target_branch}}
           git merge --squash ${{ needs.create-new-branch.outputs.BRANCH_NAME }} -m "[Automated] Merged {source_ref} into target {target_branch} during release process"
           git push

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -353,7 +353,7 @@ jobs:
       - name: Set sha for release
         id: final_sha
         run: |
-          if [[ ${{ needs.audit-changelog.outputs.exists }} -eq false ]] || [[ ${{ needs.check-current-version.outputs.up_to_date }} -eq false ]]
+          if [[ ${{ needs.audit-changelog.outputs.exists }} == false ]] || [[ ${{ needs.check-current-version.outputs.up_to_date }} == false ]]
           then
             echo "::set-output name=final_sha::$(git rev-parse HEAD)"
           else

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -252,7 +252,7 @@ jobs:
   run-tests:
   # TODO: this used to specify just unit tests, if we don't specify TOXENV it will run all tests - seems preferable?
     runs-on: ubuntu-latest
-    needs: [create-new-branch, generate-changelog, bump-version]
+    needs: [create-new-branch, generate-changelog-bump-version]
 
     steps:
       - name: Skip for now

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -59,9 +59,10 @@ jobs:
     steps:
       - name: Print variables
         run: |
-            echo The last commit sha in the release: ${{ inputs.sha }}
-            echo The release version number: ${{ inputs.version_number }}
-            echo The branch to release from: ${{ inputs.target_branch }}
+            echo sha: ${{ inputs.sha }}
+            echo version_number: ${{ inputs.version_number }}
+            echo target_branch: ${{ inputs.target_branch }}
+            echo testing: ${{ inputs.testing }}
 
   audit-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -1,0 +1,356 @@
+# **what?**
+# Perform the version bump, batch and merge the changelog and run tests.
+#
+# Inputs:
+#  sha: the commit to attach to this release
+#  version_number: version number for the release (ex: 1.2.3rc2)
+#  target_branch: The branch that we will release from
+#
+# Outputs:
+#   final_sha: The sha that will actually be released.  This can differ from the
+#              input sha if adding a version bump and/or changelog
+#   changelog_path: path to the changelof file (ex .changes/1.2.3-rc1.md)
+#
+# **why?**
+# Reusable and consistent GitHub release process.
+#
+# **when?**
+# Call when ready to kick off a build and release
+#
+
+name: Version Bump and Changelog Generation
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        required: true
+        type: string
+      version_number:
+        required: true
+        type: string
+      target_branch:
+        required: true
+        type: string
+    outputs:
+      final_sha:
+        description: The new commit that includes the changelog and version bump.
+        value: ${{ jobs.get-release-sha.outputs.final_sha }}
+      changelog_path:
+        description: The path to the changelog for this version
+        value: ${{ jobs.audit-changelog.outputs.changelog_path }}
+
+permissions:
+  contents: write
+
+jobs:
+  log-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print variables
+        run: |
+            echo The last commit sha in the release: ${{ inputs.sha }}
+            echo The release version number: ${{ inputs.version_number }}
+            echo The branch to release from: ${{ inputs.target_branch }}
+
+  audit-changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      changelog_path: ${{ steps.set_path.outputs.changelog_path }}
+      exists: ${{ steps.set_existence.outputs.exists }}
+      base_version: ${{ steps.semver.outputs.base-version }}
+      prerelease: ${{ steps.semver.outputs.pre-release }}
+      is_prerelease: ${{ steps.semver.outputs.is-pre-release }}
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Audit Version and Parse Into Parts
+        id: semver
+        uses: dbt-labs/actions/parse-semver@v1
+        with:
+          version: ${{ inputs.version_number }}
+
+      - name: Set Changelog Path
+        id: set_path
+        run: |
+          if [[ ${{ steps.semver.outputs.is-pre-release }} -eq 1 ]]
+          then
+            echo '::set-output name=changelog_path::.changes/${{ steps.semver.outputs.base-version }}-${{ steps.semver.outputs.pre-release }}.md'
+          else
+            echo '::set-output name=changelog_path::.changes/${{ steps.semver.outputs.version }}.md'
+          fi
+
+      - name: Set Changelog Existence for Other Jobs
+        id: set_existence
+        run: |
+          if test -f ${{ steps.set_path.outputs.changelog_path }}
+          then
+            echo "::set-output name=exists::true"
+          else
+            echo "::set-output name=exists::false"
+          fi
+
+      - name: Job Output
+        run: |
+          echo changelog_path ${{ steps.set_path.outputs.changelog_path }}
+          echo exists ${{ steps.set_existence.outputs.exists }}
+          echo base_version ${{ steps.semver.outputs.base-version }}
+          echo prerelease ${{ steps.semver.outputs.pre-release }}
+          echo is_prerelease ${{ steps.semver.outputs.is-pre-release }}
+
+  check-current-version:
+    runs-on: ubuntu-latest
+    outputs:
+      up_to_date:  ${{ steps.set_status.outputs.up_to_date }}
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Check Current Version in code
+        id: set_status
+        run: |
+          if grep -Fxq "current_version = ${{ inputs.version_number }}" .bumpversion.cfg
+          then
+            echo "::set-output name=up_to_date::true"
+          else
+            echo "::set-output name=up_to_date::false"
+          fi
+
+      - name: Job Output
+        run: echo up_to_date ${{ steps.set_status.outputs.up_to_date }}
+
+  skip-generate-changelog:
+    runs-on: ubuntu-latest
+    needs: [audit-changelog]
+    if: needs.audit-changelog.outputs.exists == 'true'
+
+    steps:
+      - name: Changelog Exists, Skip Release Prep
+        run: echo A changelog file already exists at ${{ needs.audit-changelog.outputs.exists }}, skipping generating changelog
+
+  skip-version-bump:
+    runs-on: ubuntu-latest
+    needs: [check-current-version]
+    if: needs.check-current-version.outputs.up_to_date == 'true'
+
+    steps:
+      - name: Version Already bumped
+        run: echo The version has already been bumped to ${{ inputs.version_number }}, skipping version bump
+
+  create-new-branch:
+    outputs:
+      branch_name: ${{steps.variables.outputs.BRANCH_NAME}}
+    runs-on: ubuntu-latest
+    needs: [audit-changelog, check-current-version]
+    if: needs.audit-changelog.outputs.exists == 'false' || needs.check-current-version.outputs.up_to_date == 'false'
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Set version value
+        id: variables
+        run: |
+          echo "::set-output name=BRANCH_NAME::prep-release/${{ inputs.version_number }}_$GITHUB_RUN_ID"
+
+      - name: Create branch
+        run: |
+          git checkout -b ${{steps.variables.outputs.BRANCH_NAME}}
+          git push origin ${{steps.variables.outputs.BRANCH_NAME}}
+          git branch --set-upstream-to=origin/${{steps.variables.outputs.BRANCH_NAME}} ${{steps.variables.outputs.BRANCH_NAME}}
+
+      - name: Push branch
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.variables.outputs.BRANCH_NAME }}
+
+      - name: Job Output
+        run: echo BRANCH_NAME ${{ steps.variables.outputs.BRANCH_NAME }}
+
+  generate-changelog:
+    runs-on: ubuntu-latest
+    needs: [audit-changelog, create-new-branch]
+    if: needs.audit-changelog.outputs.exists == 'false'
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{needs.create-new-branch.outputs.BRANCH_NAME}}
+
+      - name: Install changie
+        run: |
+          brew tap miniscruff/changie https://github.com/miniscruff/changie
+          brew install changie
+
+      - name: Generate Pre Release Changelog
+        if: needs.audit-changelog.outputs.is_prerelease == 1
+        run: |
+          changie batch ${{ needs.audit-changelog.outputs.base_version }} --move-dir '${{ needs.audit-changelog.outputs.base_version }}' --prerelease ${{ needs.audit-changelog.outputs.prerelease }}
+          changie merge
+      
+      - name: Generate Final Release Changelog
+        if: needs.audit-changelog.outputs.is_prerelease == 0
+        run: |
+          changie batch ${{ needs.audit-changelog.outputs.base_version }}  --include '${{ needs.audit-changelog.outputs.base_version }}' --remove-prereleases
+          changie merge
+      
+      - name: Check Changelog Created Successfully
+        run: |
+          if [[ -f ${{ needs.audit-changelog.outputs.changelog_path }} ]]
+          then
+            echo Changelog file created successfully
+          else
+            echo Changelog failed to generate.  Exiting.
+            exit 1
+          fi
+
+      # TODO: can do this with just the command line instead of external action
+      - name: Commit changelog to branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: 'Github Build Bot'
+          author_email: 'buildbot@fishtownanalytics.com'
+          message: 'Generated changelog for version ${{ inputs.version_number }}'
+          branch: ${{needs.create-new-branch.outputs.BRANCH_NAME}}
+          push: origin origin/${{needs.create-new-branch.outputs.BRANCH_NAME}}
+      
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{needs.create-new-branch.outputs.BRANCH_NAME}}
+
+  bump-version:
+    runs-on: ubuntu-latest
+    needs: [check-current-version, create-new-branch]
+    if: needs.check-current-version.outputs.up_to_date == 'false'
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install python dependencies
+        run: |
+          python3 -m venv env
+          source env/bin/activate
+          pip install --upgrade pip
+
+      - name: Bump version
+        # note: bumpversion is no longer supported, it actually points to bump2version now
+        run: |
+          source env/bin/activate
+          pip install -r dev-requirements.txt
+          env/bin/bumpversion --allow-dirty --new-version ${{inputs.version_number}} major
+          git status
+
+      # TODO: can do this with just the command line instead of external action
+      - name: Commit version bump to branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: 'Github Build Bot'
+          author_email: 'buildbot@fishtownanalytics.com'
+          message: 'Bumping version to ${{ inputs.version_number }}'
+          branch: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+          push: origin origin/${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+      
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+
+  run-tests:
+  # TODO: this used to specify just unit tests, if we don't specify TOXENV it will run all tests - seems preferable?
+    runs-on: ubuntu-latest
+    needs: [create-new-branch, generate-changelog, bump-version]
+
+    steps:
+      - name: Skip for now
+        run: echo Not set up for testing yet
+      # - name: Check out the repository
+      #   uses: actions/checkout@v2
+      #   with:
+      #     ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+
+      # - name: Set up Python
+      #   uses: actions/setup-python@v2
+      #   with:
+      #     python-version: 3.8
+
+      # - name: Install python dependencies
+      #   run: |
+      #     pip install --user --upgrade pip
+      #     pip install tox
+      #     pip --version
+      #     tox --version
+
+      # - name: Run tox
+      #   run: tox
+  
+  merge-for-release:
+    runs-on: ubuntu-latest
+    needs: [run-tests, create-new-branch]
+
+    steps:
+      - name: Log Values
+        run: |
+          echo inputs.target_branch ${{ inputs.target_branch }}
+          echo needs.create-new-branch.outputs.BRANCH_NAME ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+      
+      - name: Check out target branch
+        uses: actions/checkout@v2
+      
+      - name: Merge changes with target branch
+        uses: everlytic/branch-merge@1.1.2
+        with:
+          source_ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+          target_branch: ${{ inputs.target_branch }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}  # TODO: probably need to use a custom PAT to override ``.latest`` protection rules
+          commit_message_template: '[Automated] Merged {source_ref} into target {target_branch} during release process'
+
+  get-release-sha:
+  # Get the sha that will be released.  If the changelog already exists on the input sha and the version has already been bumped,
+  # then it is what we will release. Otherwise we generated a changelog and did the version bump in this workflow and there is a
+  # new sha to use from the merge we just did.  Grab that here instead.
+    outputs:
+      final_sha: ${{ steps.final_sha.outputs.final_sha }}
+    runs-on: ubuntu-latest
+    needs: [merge-for-release, audit-changelog, check-current-version]
+    # always run this job, regardness of if the dependant jobs were skipped
+    if: always()
+
+    steps:
+      - name: Check out target branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.target_branch }}
+
+      - name: Set sha for release
+        id: final_sha
+        run: |
+          if [[ ${{ needs.audit-changelog.outputs.exists }} -eq false ]] || [[ ${{ needs.check-current-version.outputs.up_to_date }} -eq false ]]
+          then
+            echo "::set-output name=final_sha::$(git rev-parse HEAD)"
+          else
+            echo "::set-output name=final_sha::${{ inputs.sha }}"
+          fi
+
+      - name: Job Output
+        run: echo final_sha ${{ steps.final_sha.outputs.final_sha }}

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -17,7 +17,12 @@
 # **when?**
 # Call when ready to kick off a build and release
 #
-# Validation Checks  TODO: add to teh top of all scripts
+# Validation Checks
+#
+#  1. Bump the version if it has not been bumped
+#  2. Generate the changelog (via changie) if there is no markdown file for this version
+#
+#
 
 name: Version Bump and Changelog Generation
 
@@ -33,6 +38,9 @@ on:
       target_branch:
         required: true
         type: string
+      testing:
+        required: true
+        type: boolean
     outputs:
       final_sha:
         description: The new commit that includes the changelog and version bump.
@@ -287,6 +295,7 @@ jobs:
   merge-for-release:
     runs-on: ubuntu-latest
     needs: [run-tests, create-new-branch]
+    if: inputs.testing == 'false'
 
     steps:
       - name: Log Values
@@ -296,20 +305,20 @@ jobs:
 
       - name: Check out target branch
         uses: actions/checkout@v3
+
+      - name: Merge changes with target branch
+        uses: everlytic/branch-merge@1.1.2
         with:
-          ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
-      
-      - name: Merge branch into target branch
-        run: |
-          git fetch origin
-          git checkout ${{ inputs.target_branch}}
-          git merge --squash ${{ needs.create-new-branch.outputs.BRANCH_NAME }} -m "[Automated] Merged {source_ref} into target {target_branch} during release process"
-          git push
-      
+          source_ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+          target_branch: ${{ inputs.target_branch }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}  # TODO: probably need to use a custom PAT to override ``.latest`` protection rules
+          commit_message_template: '[Automated] Merged {source_ref} into target {target_branch} during release process'
+
   get-release-sha:
   # Get the sha that will be released.  If the changelog already exists on the input sha and the version has already been bumped,
   # then it is what we will release. Otherwise we generated a changelog and did the version bump in this workflow and there is a
   # new sha to use from the merge we just did.  Grab that here instead.
+  # If we are testing the release, we never merged into the target branch so that's what we need to get the sh of.
     outputs:
       final_sha: ${{ steps.final_sha.outputs.final_sha }}
     runs-on: ubuntu-latest
@@ -319,9 +328,20 @@ jobs:
 
     steps:
       - name: Check out target branch
+        if: inputs.testing == 'false'
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.target_branch }}
+        run: |
+          echo Checking out ${{ inputs.target_branch }}
+
+      - name: Check out target branch
+        if: inputs.testing == 'true'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+        run: |
+          echo Checking out ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
 
       - name: Set sha for release
         id: final_sha

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -1,15 +1,16 @@
 # **what?**
-# Perform the version bump, batch and merge the changelog and run tests.
+# Perform the version bump, generate the changelog and run tests.
 #
 # Inputs:
 #  sha: the commit to attach to this release
 #  version_number: version number for the release (ex: 1.2.3rc2)
 #  target_branch: The branch that we will release from
+#  testing: true or false for if this is a test of the release process
 #
 # Outputs:
 #   final_sha: The sha that will actually be released.  This can differ from the
 #              input sha if adding a version bump and/or changelog
-#   changelog_path: path to the changelof file (ex .changes/1.2.3-rc1.md)
+#   changelog_path: path to the changelog file (ex .changes/1.2.3-rc1.md)
 #
 # **why?**
 # Reusable and consistent GitHub release process.
@@ -21,7 +22,7 @@
 #
 #  1. Bump the version if it has not been bumped
 #  2. Generate the changelog (via changie) if there is no markdown file for this version
-#
+#  3. Only merge into the target branch when not testing, otherwise point to commit on new branch
 #
 
 name: Version Bump and Changelog Generation

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -332,16 +332,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.target_branch }}
-        run: |
-          echo Checking out ${{ inputs.target_branch }}
 
       - name: Check out target branch
         if: inputs.testing == 'true'
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
-        run: |
-          echo Checking out ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+
+      - name: Log branch
+        run: git status
 
       - name: Set sha for release
         id: final_sha

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -298,12 +298,13 @@ jobs:
       - name: Check out target branch
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.target_branch }}
+          ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
       
       - name: Merge branch into target branch
         run: |
-          git pull
+          git switch ${{ inputs.target_branch }}
           git merge --squash ${{ needs.create-new-branch.outputs.BRANCH_NAME }} -m "[Automated] Merged {source_ref} into target {target_branch} during release process"
+          git push
       
   get-release-sha:
   # Get the sha that will be released.  If the changelog already exists on the input sha and the version has already been bumped,

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -215,21 +215,13 @@ jobs:
             exit 1
           fi
 
-      # TODO: can do this with just the command line instead of external action
-      - name: Commit changelog to branch
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: 'Github Build Bot'
-          author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Generated changelog for version ${{ inputs.version_number }}'
-          branch: ${{needs.create-new-branch.outputs.BRANCH_NAME}}
-          push: origin origin/${{needs.create-new-branch.outputs.BRANCH_NAME}}
-      
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{needs.create-new-branch.outputs.BRANCH_NAME}}
+      - name: Commit & Push changes
+        run: |
+          git config user.name 'Github Build Bot'
+          git config user.email 'buildbot@fishtownanalytics.com'
+          git add .
+          git commit -m "Generated changelog for version ${{ inputs.version_number }}"
+          git push
 
   bump-version:
     runs-on: ubuntu-latest
@@ -260,22 +252,14 @@ jobs:
           env/bin/bumpversion --allow-dirty --new-version ${{inputs.version_number}} major
           git status
 
-      # TODO: can do this with just the command line instead of external action
-      - name: Commit version bump to branch
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: 'Github Build Bot'
-          author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{ inputs.version_number }}'
-          branch: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
-          push: origin origin/${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+      - name: Commit & Push changes
+        run: |
+          git config user.name 'Github Build Bot'
+          git config user.email 'buildbot@fishtownanalytics.com'
+          git add .
+          git commit -m "Bumping version to ${{ inputs.version_number }}"
+          git push
       
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
-
   run-tests:
   # TODO: this used to specify just unit tests, if we don't specify TOXENV it will run all tests - seems preferable?
     runs-on: ubuntu-latest
@@ -314,17 +298,12 @@ jobs:
           echo inputs.target_branch ${{ inputs.target_branch }}
           echo needs.create-new-branch.outputs.BRANCH_NAME ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
       
-      - name: Check out target branch
-        uses: actions/checkout@v2
+      - name: Merge branch into target branch
+        run: |
+          git checkout ${{ inputs.target_branch }}
+          git pull
+          git merge ${{ needs.create-new-branch.outputs.BRANCH_NAME }} -m "[Automated] Merged {source_ref} into target {target_branch} during release process" --squash
       
-      - name: Merge changes with target branch
-        uses: everlytic/branch-merge@1.1.2
-        with:
-          source_ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
-          target_branch: ${{ inputs.target_branch }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}  # TODO: probably need to use a custom PAT to override ``.latest`` protection rules
-          commit_message_template: '[Automated] Merged {source_ref} into target {target_branch} during release process'
-
   get-release-sha:
   # Get the sha that will be released.  If the changelog already exists on the input sha and the version has already been bumped,
   # then it is what we will release. Otherwise we generated a changelog and did the version bump in this workflow and there is a

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -221,6 +221,7 @@ jobs:
           git config user.email 'buildbot@fishtownanalytics.com'
           git add .
           git commit -m "Generated changelog for version ${{ inputs.version_number }}"
+          git pull
           git push
 
   bump-version:
@@ -258,6 +259,7 @@ jobs:
           git config user.email 'buildbot@fishtownanalytics.com'
           git add .
           git commit -m "Bumping version to ${{ inputs.version_number }}"
+          git pull
           git push
       
   run-tests:
@@ -297,10 +299,14 @@ jobs:
         run: |
           echo inputs.target_branch ${{ inputs.target_branch }}
           echo needs.create-new-branch.outputs.BRANCH_NAME ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+
+      - name: Check out target branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.target_branch }}
       
       - name: Merge branch into target branch
         run: |
-          git checkout ${{ inputs.target_branch }}
           git pull
           git merge ${{ needs.create-new-branch.outputs.BRANCH_NAME }} -m "[Automated] Merged {source_ref} into target {target_branch} during release process" --squash
       

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -5,7 +5,6 @@
 #  sha: the commit to attach to this release
 #  version_number: version number for the release (ex: 1.2.3rc2)
 #  target_branch: The branch that we will release from
-#  testing: true or false for if this is a test of the release process
 #
 # Outputs:
 #   final_sha: The sha that will actually be released.  This can differ from the
@@ -22,7 +21,6 @@
 #
 #  1. Bump the version if it has not been bumped
 #  2. Generate the changelog (via changie) if there is no markdown file for this version
-#  3. Only merge into the target branch when not testing, otherwise point to commit on new branch
 #
 
 name: Version Bump and Changelog Generation
@@ -37,9 +35,6 @@ on:
         required: true
         type: string
       target_branch:
-        required: true
-        type: string
-      testing:
         required: true
         type: string
     outputs:
@@ -281,7 +276,6 @@ jobs:
   merge-for-release:
     runs-on: ubuntu-latest
     needs: [run-tests, create-new-branch]
-    if: inputs.testing == 'false'
 
     steps:
       - name: Log Values
@@ -304,7 +298,6 @@ jobs:
   # Get the sha that will be released.  If the changelog already exists on the input sha and the version has already been bumped,
   # then it is what we will release. Otherwise we generated a changelog and did the version bump in this workflow and there is a
   # new sha to use from the merge we just did.  Grab that here instead.
-  # If we are testing the release, we never merged into the target branch so that's what we need to get the sh of.
     outputs:
       final_sha: ${{ steps.final_sha.outputs.final_sha }}
     runs-on: ubuntu-latest
@@ -315,23 +308,15 @@ jobs:
     steps:
       - name: Log Inputs
         run: |
-          echo testing: ${{ inputs.testing }}
           echo target_branch: ${{ inputs.target_branch }}
           echo new branch: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
           echo changelog exists: ${{ needs.audit-changelog.outputs.exists }}
           echo version up to date: ${{ needs.check-current-version.outputs.up_to_date }}
 
       - name: Check out target branch
-        if: inputs.testing == 'false'
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.target_branch }}
-
-      - name: Check out testing branch
-        if: inputs.testing == 'true'
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
 
       - name: Log branch
         run: git status

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -213,6 +213,7 @@ jobs:
         run: |
           git config user.name 'Github Build Bot'
           git config user.email 'buildbot@fishtownanalytics.com'
+          git pull
           git add .
           git commit -m "Generated changelog for version ${{ inputs.version_number }}"
           git push
@@ -250,6 +251,7 @@ jobs:
         run: |
           git config user.name 'Github Build Bot'
           git config user.email 'buildbot@fishtownanalytics.com'
+          git pull
           git add .
           git commit -m "Bumping version to ${{ inputs.version_number }}"
           git push

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -40,7 +40,7 @@ on:
         type: string
       testing:
         required: true
-        type: boolean
+        type: string
     outputs:
       final_sha:
         description: The new commit that includes the changelog and version bump.

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -17,6 +17,7 @@
 # **when?**
 # Call when ready to kick off a build and release
 #
+# Validation Checks  TODO: add to teh top of all scripts
 
 name: Version Bump and Changelog Generation
 
@@ -168,12 +169,6 @@ jobs:
           git push origin ${{steps.variables.outputs.BRANCH_NAME}}
           git branch --set-upstream-to=origin/${{steps.variables.outputs.BRANCH_NAME}} ${{steps.variables.outputs.BRANCH_NAME}}
 
-      - name: Push branch
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.variables.outputs.BRANCH_NAME }}
-
       - name: Job Output
         run: echo BRANCH_NAME ${{ steps.variables.outputs.BRANCH_NAME }}
 
@@ -308,7 +303,7 @@ jobs:
       - name: Merge branch into target branch
         run: |
           git pull
-          git merge ${{ needs.create-new-branch.outputs.BRANCH_NAME }} -m "[Automated] Merged {source_ref} into target {target_branch} during release process" --squash
+          git merge --squash ${{ needs.create-new-branch.outputs.BRANCH_NAME }} -m "[Automated] Merged {source_ref} into target {target_branch} during release process"
       
   get-release-sha:
   # Get the sha that will be released.  If the changelog already exists on the input sha and the version has already been bumped,

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -166,8 +166,7 @@ jobs:
       - name: Create branch
         run: |
           git checkout -b ${{steps.variables.outputs.BRANCH_NAME}}
-          git push origin ${{steps.variables.outputs.BRANCH_NAME}}
-          git branch --set-upstream-to=origin/${{steps.variables.outputs.BRANCH_NAME}} ${{steps.variables.outputs.BRANCH_NAME}}
+          git push -u origin ${{steps.variables.outputs.BRANCH_NAME}}
 
       - name: Job Output
         run: echo BRANCH_NAME ${{ steps.variables.outputs.BRANCH_NAME }}
@@ -214,7 +213,6 @@ jobs:
         run: |
           git config user.name 'Github Build Bot'
           git config user.email 'buildbot@fishtownanalytics.com'
-          git pull
           git add .
           git commit -m "Generated changelog for version ${{ inputs.version_number }}"
           git push
@@ -252,7 +250,6 @@ jobs:
         run: |
           git config user.name 'Github Build Bot'
           git config user.email 'buildbot@fishtownanalytics.com'
-          git pull
           git add .
           git commit -m "Bumping version to ${{ inputs.version_number }}"
           git push
@@ -302,7 +299,7 @@ jobs:
       
       - name: Merge branch into target branch
         run: |
-          git switch ${{ inputs.target_branch }}
+          git checkout ${{ inputs.target_branch}}
           git merge --squash ${{ needs.create-new-branch.outputs.BRANCH_NAME }} -m "[Automated] Merged {source_ref} into target {target_branch} during release process"
           git push
       

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.audit-changelog.outputs.exists == 'true'
 
     steps:
-      - name: Changelog Exists, Skip Release Prep
+      - name: Changelog Exists, Skip Generating New Changelog
         run: echo A changelog file already exists at ${{ needs.audit-changelog.outputs.exists }}, skipping generating changelog
 
   skip-version-bump:
@@ -180,10 +180,9 @@ jobs:
       - name: Job Output
         run: echo BRANCH_NAME ${{ steps.variables.outputs.BRANCH_NAME }}
 
-  generate-changelog:
+  generate-changelog-bump-version:
     runs-on: ubuntu-latest
-    needs: [audit-changelog, create-new-branch]
-    if: needs.audit-changelog.outputs.exists == 'false'
+    needs: [audit-changelog, check-current-version, create-new-branch]
 
     steps:
       - name: Check out the repository
@@ -192,23 +191,25 @@ jobs:
           ref: ${{needs.create-new-branch.outputs.BRANCH_NAME}}
 
       - name: Install changie
+        if: needs.audit-changelog.outputs.exists == 'false'
         run: |
           brew tap miniscruff/changie https://github.com/miniscruff/changie
           brew install changie
 
       - name: Generate Pre Release Changelog
-        if: needs.audit-changelog.outputs.is_prerelease == 1
+        if: needs.audit-changelog.outputs.is_prerelease == 1 && needs.audit-changelog.outputs.exists == 'false'
         run: |
           changie batch ${{ needs.audit-changelog.outputs.base_version }} --move-dir '${{ needs.audit-changelog.outputs.base_version }}' --prerelease ${{ needs.audit-changelog.outputs.prerelease }}
           changie merge
       
       - name: Generate Final Release Changelog
-        if: needs.audit-changelog.outputs.is_prerelease == 0
+        if: needs.audit-changelog.outputs.is_prerelease == 0 && needs.audit-changelog.outputs.exists == 'false'
         run: |
           changie batch ${{ needs.audit-changelog.outputs.base_version }}  --include '${{ needs.audit-changelog.outputs.base_version }}' --remove-prereleases
           changie merge
       
       - name: Check Changelog Created Successfully
+        if: needs.audit-changelog.outputs.exists == 'false'
         run: |
           if [[ -f ${{ needs.audit-changelog.outputs.changelog_path }} ]]
           then
@@ -218,37 +219,20 @@ jobs:
             exit 1
           fi
 
-      - name: Commit & Push changes
-        run: |
-          git config user.name 'Github Build Bot'
-          git config user.email 'buildbot@fishtownanalytics.com'
-          git pull
-          git add .
-          git commit -m "Generated changelog for version ${{ inputs.version_number }}"
-          git push
-
-  bump-version:
-    runs-on: ubuntu-latest
-    needs: [check-current-version, create-new-branch]
-    if: needs.check-current-version.outputs.up_to_date == 'false'
-
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
-
       - uses: actions/setup-python@v2
+        if: needs.check-current-version.outputs.up_to_date == 'false'
         with:
           python-version: "3.8"
 
       - name: Install python dependencies
+        if: needs.check-current-version.outputs.up_to_date == 'false'
         run: |
           python3 -m venv env
           source env/bin/activate
           pip install --upgrade pip
 
       - name: Bump version
+        if: needs.check-current-version.outputs.up_to_date == 'false'
         # note: bumpversion is no longer supported, it actually points to bump2version now
         run: |
           source env/bin/activate
@@ -262,7 +246,7 @@ jobs:
           git config user.email 'buildbot@fishtownanalytics.com'
           git pull
           git add .
-          git commit -m "Bumping version to ${{ inputs.version_number }}"
+          git commit -m "Bumping version to ${{ inputs.version_number }} and generate changelog"
           git push
       
   run-tests:

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -219,9 +219,9 @@ jobs:
         run: |
           git config user.name 'Github Build Bot'
           git config user.email 'buildbot@fishtownanalytics.com'
+          git pull
           git add .
           git commit -m "Generated changelog for version ${{ inputs.version_number }}"
-          git pull
           git push
 
   bump-version:
@@ -257,9 +257,9 @@ jobs:
         run: |
           git config user.name 'Github Build Bot'
           git config user.email 'buildbot@fishtownanalytics.com'
+          git pull
           git add .
           git commit -m "Bumping version to ${{ inputs.version_number }}"
-          git pull
           git push
       
   run-tests:

--- a/.github/workflows/_release-prep.yml
+++ b/.github/workflows/_release-prep.yml
@@ -322,18 +322,26 @@ jobs:
     outputs:
       final_sha: ${{ steps.final_sha.outputs.final_sha }}
     runs-on: ubuntu-latest
-    needs: [merge-for-release, audit-changelog, check-current-version]
+    needs: [create-new-branch, merge-for-release, audit-changelog, check-current-version]
     # always run this job, regardness of if the dependant jobs were skipped
     if: always()
 
     steps:
+      - name: Log Inputs
+        run: |
+          echo testing: ${{ inputs.testing }}
+          echo target_branch: ${{ inputs.target_branch }}
+          echo new branch: ${{ needs.create-new-branch.outputs.BRANCH_NAME }}
+          echo changelog exists: ${{ needs.audit-changelog.outputs.exists }}
+          echo version up to date: ${{ needs.check-current-version.outputs.up_to_date }}
+
       - name: Check out target branch
         if: inputs.testing == 'false'
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.target_branch }}
 
-      - name: Check out target branch
+      - name: Check out testing branch
         if: inputs.testing == 'true'
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Resolves: #14 

Purpose: Perform the version bump and generate the changelog before building the release artifacts
- If version has already been bumped, don't fail, just skip that step
- If Changelog markdown file has already been generated for this release, don't fail, just skip generating a new one
- The changelog is generated per with changie.  The file will be used as release notes in GitHub.
- After bumping the version and generating the changelog, commit the changes to a new branch and run all tests.  If tests pass, merge into target_branch.

Output the new commit sha for the rest of the release process

### Left To Do
- Uncomment test section and ensure it's complete.
