### PR TITLE
Release to Pypi Workflow for Automated Release Process

### DIFF
--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -54,28 +54,26 @@ jobs:
       exists: ${{ steps.set_existence.outputs.exists }}
   
     steps:
-      - name: Placeholder
-        run: echo Workflow is not built
-
       - name: Check PyPI
-        id: pypi
-        continue-on-error: true
+        id: pypi_info
         uses: dbt-labs/actions/py-package-info@v1
         with:
           package: ${{ github.event.repository.name }}
           version: ${{ inputs.version_number }}
+          # test: ${{ inputs.testing }}  TODO: implement in action
       
       - name: Set Outputs
-        id: set_status
-        run: |
-          # docs on conclusion vs outcome - https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
-          [ "${{ steps.invalid-package.conclusion }}" != success ] && exit 1 # confirm `invalid-package` step ran to completion
-          [ "${{ steps.invalid-package.outcome }}" != failure ] && exit 1 # confirm `invalid-package` step failed
-          exit 0
-
-      - name: Set output
+      # The above step will just use the latest version if the input version
+      # is not found.  So to validate the version we want to release exists
+      # we need to compare teh output version.
         id: set_existence
-        run: echo '::set-output name=exists::true'
+        run: |
+          if [[ ${{ steps.pypi_info.version }} != ${{ inputs.tag }} ]]
+          then
+            echo '::set-output name=exists::false'
+          else
+            echo '::set-output name=exists::true'
+          fi
 
   skip-pypi-release:
     runs-on: ubuntu-latest
@@ -129,13 +127,21 @@ jobs:
     if: always()
 
     steps:
-      - name: Check the package successfully released to PyPI
-        run: echo Need to implement this
+      - name: Check PyPI
+        id: pypi_info
+        uses: dbt-labs/actions/py-package-info@v1
+        with:
+          package: ${{ github.event.repository.name }}
+          version: ${{ inputs.version_number }}
+          # test: ${{ inputs.testing }}  TODO: implement in action
       
       - name: Set output
+      # The above step will just use the latest version if the input version
+      # is not found.  So to validate the version we want to release exists
+      # we need to compare teh output version.
         id: set_existence
         run: |
-          if [[ exists == true ]]
+          if [[ ${{ steps.pypi_info.version }} != ${{ inputs.tag }} ]]
           then
             echo ${{ inputs.tag }} released to Pypi
           else

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -2,11 +2,11 @@
 # After releasing to GitHub, release to Pypi
 #
 # Inputs:
-#   tag - tag of release in the format v1.2.3rc1
-#   testing - true is releasing to test pypi, otherwise false
+#   tag: tag of release in the format v1.2.3rc1
+#   testing: true is releasing to test pypi, otherwise false
 # 
 # **why?**
-# Automate teh release process
+# Automate the release process
 #
 # **when?**
 #  After successfully releasing to GitHub
@@ -66,12 +66,30 @@ jobs:
       - name: Pypi Release Exists, Skip
         run: echo A release already exists for this version ${{ inputs.tag }} on Pypi, skipping
 
-  pypi-release:
+  test-pypi-release:
     needs: [check-pypi-exists]
-    if: needs.check-pypi-exists.outputs.exists == 'false'
+    if: needs.check-pypi-exists.outputs.exists == 'false' && ${{ inputs.testing }} == 'false'
     runs-on: ubuntu-latest
   
-    environment: PypiProd  # TODO: what's this? Could make be input for testing purposes?
+    environment: PypiTest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: 'dist'
+
+      - name: Publish distribution to test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.5
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  prod-pypi-release:
+    needs: [check-pypi-exists]
+    if: needs.check-pypi-exists.outputs.exists == 'false'  && ${{ inputs.testing }} == 'true'
+    runs-on: ubuntu-latest
+  
+    environment: PypiProd
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -83,10 +101,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.5
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Publish distribution to test PyPI
-        if: ${{ inputs.testing }} == 'false'
-        uses: pypa/gh-action-pypi-publish@v1.5
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -68,7 +68,7 @@ jobs:
       # we need to compare the output version.
         id: set_existence
         run: |
-          if [[ ${{ steps.pypi_info.version }} != ${{ inputs.tag }} ]]
+          if [[ ${{ steps.pypi_info.outputs.version }} != ${{ inputs.tag }} ]]
           then
             echo '::set-output name=exists::false'
           else

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -26,7 +26,7 @@ on:
         type: string
       testing:
         required: true
-        type: boolean
+        type: string
     # pass through secrets for both PyPi Test and Prod so they're always there
     # secrets:
     #   PYPI_API_TOKEN:

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -139,7 +139,7 @@ jobs:
   #       uses: dbt-labs/actions/py-package-info@v1
   #       with:
   #         package: ${{ github.event.repository.name }}
-  #         version: ${{ inputs.version_number }}
+  #         version: ${{ inputs.tag }}
   #         # test: ${{ inputs.testing }}  TODO: implement in action
       
   #     - name: Set output

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: dbt-labs/actions/py-package-info@v1
         with:
           package: ${{ github.event.repository.name }}
-          version: ${{ inputs.version_number }}
+          version: ${{ inputs.tag }}
           # test: ${{ inputs.testing }}  TODO: implement in action
       
       - name: Set Outputs

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -70,8 +70,10 @@ jobs:
         run: |
           if [[ ${{ steps.pypi_info.outputs.version }} != ${{ inputs.tag }} ]]
           then
+            echo PyPI Package not found for ${{ inputs.tag }}
             echo '::set-output name=exists::false'
           else
+            echo PyPI Package found for ${{ inputs.tag }}.  Skip release.
             echo '::set-output name=exists::true'
           fi
       

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -28,13 +28,13 @@ on:
         required: true
         type: boolean
     # pass through secrets for both PyPi Test and Prod so they're always there
-    secrets:
-      PYPI_API_TOKEN:
-        description: AWS Access Key ID
-        required: true
-      TEST_PYPI_API_TOKEN:
-        description: Test Pypi api token
-        required: true
+    # secrets:
+    #   PYPI_API_TOKEN:
+    #     description: AWS Access Key ID
+    #     required: true
+    #   TEST_PYPI_API_TOKEN:
+    #     description: Test Pypi api token
+    #     required: true
 
 permissions:
   contents: read
@@ -65,7 +65,7 @@ jobs:
       - name: Set Outputs
       # The above step will just use the latest version if the input version
       # is not found.  So to validate the version we want to release exists
-      # we need to compare teh output version.
+      # we need to compare the output version.
         id: set_existence
         run: |
           if [[ ${{ steps.pypi_info.version }} != ${{ inputs.tag }} ]]
@@ -89,68 +89,68 @@ jobs:
       - name: PyPI Release Exists, Skip
         run: echo A release already exists for this version ${{ inputs.tag }} on Pypi, skipping
 
-  test-pypi-release:
-    runs-on: ubuntu-latest
-    needs: [check-pypi-exists]
-    if: needs.check-pypi-exists.outputs.exists == 'false' && ${{ inputs.testing }} == 'false'
+  # test-pypi-release:
+  #   runs-on: ubuntu-latest
+  #   needs: [check-pypi-exists]
+  #   if: needs.check-pypi-exists.outputs.exists == 'false' && ${{ inputs.testing }} == 'false'
   
-    environment: PypiTest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: 'dist'
+  #   environment: PypiTest
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: dist
+  #         path: 'dist'
 
-      - name: Publish distribution to test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+  #     - name: Publish distribution to test PyPI
+  #       uses: pypa/gh-action-pypi-publish@v1.5
+  #       with:
+  #         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  #         repository_url: https://test.pypi.org/legacy/
 
-  prod-pypi-release:
-    runs-on: ubuntu-latest
-    needs: [check-pypi-exists]
-    if: needs.check-pypi-exists.outputs.exists == 'false'  && ${{ inputs.testing }} == 'true'
+  # prod-pypi-release:
+  #   runs-on: ubuntu-latest
+  #   needs: [check-pypi-exists]
+  #   if: needs.check-pypi-exists.outputs.exists == 'false'  && ${{ inputs.testing }} == 'true'
   
-    environment: PypiProd
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: 'dist'
+  #   environment: PypiProd
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: dist
+  #         path: 'dist'
 
-      - name: Publish distribution to PyPI
-        if: ${{ inputs.testing }} == 'true'
-        uses: pypa/gh-action-pypi-publish@v1.5
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  #     - name: Publish distribution to PyPI
+  #       if: ${{ inputs.testing }} == 'true'
+  #       uses: pypa/gh-action-pypi-publish@v1.5
+  #       with:
+  #         password: ${{ secrets.PYPI_API_TOKEN }}
 
-  validate-pypi-package:
-    runs-on: ubuntu-latest
-    needs: [test-pypi-release, prod-pypi-release]
-    # always run this step because one of the needs are always skipped.
-    if: always()
+  # validate-pypi-package:
+  #   runs-on: ubuntu-latest
+  #   needs: [test-pypi-release, prod-pypi-release]
+  #   # always run this step because one of the needs are always skipped.
+  #   if: always()
 
-    steps:
-      - name: Check PyPI
-        id: pypi_info
-        uses: dbt-labs/actions/py-package-info@v1
-        with:
-          package: ${{ github.event.repository.name }}
-          version: ${{ inputs.version_number }}
-          # test: ${{ inputs.testing }}  TODO: implement in action
+  #   steps:
+  #     - name: Check PyPI
+  #       id: pypi_info
+  #       uses: dbt-labs/actions/py-package-info@v1
+  #       with:
+  #         package: ${{ github.event.repository.name }}
+  #         version: ${{ inputs.version_number }}
+  #         # test: ${{ inputs.testing }}  TODO: implement in action
       
-      - name: Set output
-      # The above step will just use the latest version if the input version
-      # is not found.  So to validate the version we want to release exists
-      # we need to compare teh output version.
-        id: set_existence
-        run: |
-          if [[ ${{ steps.pypi_info.version }} != ${{ inputs.tag }} ]]
-          then
-            echo ${{ inputs.tag }} released to Pypi
-          else
-            echo ${{ inputs.tag }} FAILED to released to Pypi.  Manual intervention required.
-            exit 1
-          fi
+  #     - name: Set output
+  #     # The above step will just use the latest version if the input version
+  #     # is not found.  So to validate the version we want to release exists
+  #     # we need to compare teh output version.
+  #       id: set_existence
+  #       run: |
+  #         if [[ ${{ steps.pypi_info.version }} != ${{ inputs.tag }} ]]
+  #         then
+  #           echo ${{ inputs.tag }} released to Pypi
+  #         else
+  #           echo ${{ inputs.tag }} FAILED to released to Pypi.  Manual intervention required.
+  #           exit 1
+  #         fi
 

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -74,6 +74,11 @@ jobs:
           else
             echo '::set-output name=exists::true'
           fi
+      
+      - name: Temp Always fail.
+        run: |
+          echo exits: ${{ steps.set_existence.outputs.exists.outputs.exists}}
+          echo '::set-output name=exists::true'
 
   skip-pypi-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -1,0 +1,92 @@
+# **what?**
+# After releasing to GitHub, release to Pypi
+#
+# Inputs:
+#   tag - tag of release in the format v1.2.3rc1
+#   testing - true is releasing to test pypi, otherwise false
+# 
+# **why?**
+# Automate teh release process
+#
+# **when?**
+#  After successfully releasing to GitHub
+#
+
+name: Pypi release
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'The tag for the release (ie. v1.0.0b1)'
+        required: true
+        type: string
+      testing:
+        required: true
+        type: boolean
+    # pass through secrets for both PyPi Test and Prod so they're always there
+    secrets:
+      PYPI_API_TOKEN:
+        description: AWS Access Key ID
+        required: true
+      TEST_PYPI_API_TOKEN:
+        description: Test Pypi api token
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  log-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print variables
+        run: |
+            echo Tag: ${{ inputs.tag }}
+            echo Release to test Pypi: ${{ inputs.testing }}
+
+  check-pypi-exists:
+    runs-on: ubuntu-latest
+    outputs:
+      exists: ${{ steps.set_existence.outputs.exists }}
+  
+    steps:
+      - name: Placeholder
+        run: echo Workflow is not built
+      - name: Set output
+        id: set_existence
+        run: echo '::set-output name=exists::false'
+
+  skip-pypi-release:
+    runs-on: ubuntu-latest
+    needs: [check-pypi-exists]
+    if: needs.check-pypi-exists.outputs.exists == 'true'
+
+    steps:
+      - name: Pypi Release Exists, Skip
+        run: echo A release already exists for this version ${{ inputs.tag }} on Pypi, skipping
+
+  pypi-release:
+    needs: [check-pypi-exists]
+    if: needs.check-pypi-exists.outputs.exists == 'false'
+    runs-on: ubuntu-latest
+  
+    environment: PypiProd  # TODO: what's this? Could make be input for testing purposes?
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: 'dist'
+
+      - name: Publish distribution to PyPI
+        if: ${{ inputs.testing }} == 'true'
+        uses: pypa/gh-action-pypi-publish@v1.5
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Publish distribution to test PyPI
+        if: ${{ inputs.testing }} == 'false'
+        uses: pypa/gh-action-pypi-publish@v1.5
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/_pypi-release.yml
+++ b/.github/workflows/_pypi-release.yml
@@ -1,9 +1,9 @@
 # **what?**
-# After releasing to GitHub, release to Pypi
+# After releasing to GitHub, release to PyPI
 #
 # Inputs:
 #   tag: tag of release in the format v1.2.3rc1
-#   testing: true is releasing to test pypi, otherwise false
+#   testing: true is releasing to test PyPI, otherwise false
 # 
 # **why?**
 # Automate the release process
@@ -11,8 +11,11 @@
 # **when?**
 #  After successfully releasing to GitHub
 #
+# Assumptions
+#  1.  The name of the repository is the name of the package on PyPI
+#
 
-name: Pypi release
+name: PyPI release
 
 on:
   workflow_call:
@@ -43,7 +46,7 @@ jobs:
       - name: Print variables
         run: |
             echo Tag: ${{ inputs.tag }}
-            echo Release to test Pypi: ${{ inputs.testing }}
+            echo Release to test PyPI: ${{ inputs.testing }}
 
   check-pypi-exists:
     runs-on: ubuntu-latest
@@ -53,9 +56,26 @@ jobs:
     steps:
       - name: Placeholder
         run: echo Workflow is not built
+
+      - name: Check PyPI
+        id: pypi
+        continue-on-error: true
+        uses: dbt-labs/actions/py-package-info@v1
+        with:
+          package: ${{ github.event.repository.name }}
+          version: ${{ inputs.version_number }}
+      
+      - name: Set Outputs
+        id: set_status
+        run: |
+          # docs on conclusion vs outcome - https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+          [ "${{ steps.invalid-package.conclusion }}" != success ] && exit 1 # confirm `invalid-package` step ran to completion
+          [ "${{ steps.invalid-package.outcome }}" != failure ] && exit 1 # confirm `invalid-package` step failed
+          exit 0
+
       - name: Set output
         id: set_existence
-        run: echo '::set-output name=exists::false'
+        run: echo '::set-output name=exists::true'
 
   skip-pypi-release:
     runs-on: ubuntu-latest
@@ -63,13 +83,13 @@ jobs:
     if: needs.check-pypi-exists.outputs.exists == 'true'
 
     steps:
-      - name: Pypi Release Exists, Skip
+      - name: PyPI Release Exists, Skip
         run: echo A release already exists for this version ${{ inputs.tag }} on Pypi, skipping
 
   test-pypi-release:
+    runs-on: ubuntu-latest
     needs: [check-pypi-exists]
     if: needs.check-pypi-exists.outputs.exists == 'false' && ${{ inputs.testing }} == 'false'
-    runs-on: ubuntu-latest
   
     environment: PypiTest
     steps:
@@ -85,9 +105,9 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
 
   prod-pypi-release:
+    runs-on: ubuntu-latest
     needs: [check-pypi-exists]
     if: needs.check-pypi-exists.outputs.exists == 'false'  && ${{ inputs.testing }} == 'true'
-    runs-on: ubuntu-latest
   
     environment: PypiProd
     steps:
@@ -101,3 +121,25 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.5
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  validate-pypi-package:
+    runs-on: ubuntu-latest
+    needs: [test-pypi-release, prod-pypi-release]
+    # always run this step because one of the needs are always skipped.
+    if: always()
+
+    steps:
+      - name: Check the package successfully released to PyPI
+        run: echo Need to implement this
+      
+      - name: Set output
+        id: set_existence
+        run: |
+          if [[ exists == true ]]
+          then
+            echo ${{ inputs.tag }} released to Pypi
+          else
+            echo ${{ inputs.tag }} FAILED to released to Pypi.  Manual intervention required.
+            exit 1
+          fi
+


### PR DESCRIPTION
Resolves: #17 

Purpose: Release to PyPI after successful GitHub Release
- If the tag is not already released to pypi, release it.
- Release to PypI test or prod, depending on value of `testing` input
- Check at the end to ensure the tag has been released to PyPI

### TODO
- [ ] Set up secrets
- [ ] actually test