### PR TITLE
add reusable version-bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,108 @@
+# **what?**
+# This workflow will take the new version number to bump to. With that
+# it will run versionbump to update the version number everywhere in the
+# code base and then run changie to create the corresponding changelog.
+# A PR will be created with the changes that can be reviewed before committing.
+
+# **why?**
+# This is to aid in releasing dbt and making sure we have updated
+# the version in all places and generated the changelog.
+
+# **when?**
+# This is triggered by a call in another workflow
+
+name: Version Bump
+
+on:
+  workflow_call:
+    inputs:
+      version_number:
+       description: 'The version number to bump to (ex. 1.2.0, 1.3.0b1)'
+       type: string
+       required: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[DEBUG] Print Variables"
+        run: |
+          echo "all variables defined as inputs"
+          echo The version_number: ${{ github.event.inputs.version_number }}
+
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install python dependencies
+        run: |
+          python3 -m venv env
+          source env/bin/activate
+          pip install --upgrade pip
+
+      - name: Audit Version and Parse Into Parts
+        id: semver
+        uses: dbt-labs/actions/parse-semver@v1
+        with:
+          version: ${{ github.event.inputs.version_number }}
+
+      - name: Set branch value
+        id: variables
+        run: |
+          echo "::set-output name=BRANCH_NAME::prep-release/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID"
+
+      - name: Create PR branch
+        run: |
+          git checkout -b ${{ steps.variables.outputs.BRANCH_NAME }}
+          git push origin ${{ steps.variables.outputs.BRANCH_NAME }}
+          git branch --set-upstream-to=origin/${{ steps.variables.outputs.BRANCH_NAME }} ${{ steps.variables.outputs.BRANCH_NAME }}
+
+      - name: Bump version
+        run: |
+          source env/bin/activate
+          pip install -r dev-requirements.txt
+          env/bin/bumpversion --allow-dirty --new-version ${{ github.event.inputs.version_number }} major
+          git status
+
+      # this step will fail on whitespace errors but also correct them
+      - name: Format bumpversion file
+        continue-on-error: true
+        run: |
+          brew install pre-commit
+          pre-commit run trailing-whitespace --files .bumpversion.cfg
+          git status
+
+      - name: Run changie
+        run: |
+          brew tap miniscruff/changie https://github.com/miniscruff/changie
+          brew install changie
+          if [[ ${{ steps.semver.outputs.is-pre-release }} -eq 1 ]]
+          then
+            changie batch ${{ steps.semver.outputs.base-version }}  --move-dir '${{ steps.semver.outputs.base-version }}' --prerelease '${{ steps.semver.outputs.pre-release }}'
+          else
+            changie batch ${{ steps.semver.outputs.base-version }}  --include '${{ steps.semver.outputs.base-version }}' --remove-prereleases
+          fi
+          changie merge
+          git status
+
+      - name: Commit version bump to branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: 'Github Build Bot'
+          author_email: 'buildbot@fishtownanalytics.com'
+          message: 'Bumping version to ${{ github.event.inputs.version_number }} and generate CHANGELOG'
+          branch: '${{ steps.variables.outputs.BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.outputs.BRANCH_NAME }}'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
+          base: ${{github.ref}}
+          title: 'Bumping version to ${{ github.event.inputs.version_number }} and generate changelog'
+          branch: '${{ steps.variables.outputs.BRANCH_NAME }}'
+          labels: |
+            Skip Changelog


### PR DESCRIPTION
Now that all the adapters use changie, we can share this action across all adapters and core since none of it is repo-specific.

It will bump the version and generate the changie log for a release.  It will open a PR in that repo that needs to be approved.  No auto-commits allowed anymore.

This is the exact workflow we currently use in `dbt-core` just with a `workflow_call` trigger instead of a `workflow_dispatch` trigger.