### PR TITLE
Adding spark dependency to version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           python-version: "3.8"
 
+      - name: Install spark dependencies
+        if: (( github.repository == 'dbt-labs/dbt-spark' ))
+        run: |
+          sudo apt-get install libsasl2-dev
+
       - name: Install python dependencies
         run: |
           python3 -m venv env


### PR DESCRIPTION
Spark needs to install an additional dependency to it's environment. The previous version bump script in the Spark repo had this specific line
https://github.com/dbt-labs/dbt-spark/commit/5297b9225263fb33338fc54f004365ec1ad47104#diff-e8ca070981ccdc3f369851c960bec6882143a0c7afe78acd7b05e0c2b0068d72L58