### PR TITLE
add PRs to Core triage project automation

### DIFF
--- a/scripts/core-triage/graphql_queries.py
+++ b/scripts/core-triage/graphql_queries.py
@@ -45,13 +45,12 @@ issues_query = """
     }
 """
 
+# TODO: add back label filtering
 # graphql query to get list of prs for the github repo
 prs_query = """
     query {
         repository(owner:$org, name:$repo) {
-            pullRequests(last:$num_items states:OPEN filterBy: {
-                labels: [$label]
-            }) {
+            pullRequests(last:$num_items states:OPEN) {
                 edges {
                     node {
                         title

--- a/scripts/core-triage/project.py
+++ b/scripts/core-triage/project.py
@@ -23,6 +23,8 @@ ISSUE_LABELS = [
     "triage",
     "bug",
     "good_first_issue",
+    "awaiting_response",
+    "support_rotation",
     "help_wanted",
     "spike",
     "python_models",
@@ -131,6 +133,7 @@ def get_issues(repo: str, label: str, num_items: int) -> list[dict]:
     )["data"]["repository"]["issues"]["edges"]
     return issues
 
+
 def get_prs(repo: str, num_items: int) -> list[dict]:
     """
     Get a list of prs for the given repo and label.
@@ -151,7 +154,6 @@ def get_prs(repo: str, num_items: int) -> list[dict]:
     return prs
 
 
-
 def add_items_to_project(project_id: str, items: list[dict]) -> None:
     """
     Adds GitHub items (issues or PRs) to a project by project_id and a list of item edges.
@@ -170,6 +172,7 @@ def add_items_to_project(project_id: str, items: list[dict]) -> None:
                 ).replace("$item_id", f'"{item["node"]["id"]}"')
             },
         )
+
 
 def main(
     project_num: int,

--- a/scripts/core-triage/project.py
+++ b/scripts/core-triage/project.py
@@ -30,7 +30,7 @@ ISSUE_LABELS = [
     "Team:Execution",
     "Team:Adapters",
 ]
-# prs added by label individually TODO: unused -- PRs currently not added (are they?)
+# prs added by label individually TODO: unused, add label filtering
 PR_LABELS = ["ready_for_review"]
 # GitHub TOKEN environment variable name TODO: make this input? hardcoded to match GH action
 TOKEN_VAR = "GH_TOKEN"
@@ -131,6 +131,26 @@ def get_issues(repo: str, label: str, num_items: int) -> list[dict]:
     )["data"]["repository"]["issues"]["edges"]
     return issues
 
+def get_prs(repo: str, num_items: int) -> list[dict]:
+    """
+    Get a list of prs for the given repo and label.
+    ---
+    Inputs: repo (str), num_items (int)
+    Outputs: prs (list of dict)
+    """
+    # replace variables in query string and filter down to the issues' edges
+    prs = process_request(
+        gh_graphql_url,
+        headers=headers,
+        json={
+            "query": prs_query.replace("$org", f'"{ORG}"')
+            .replace("$repo", f'"{repo}"')
+            .replace("$num_items", f"{num_items}")
+        },
+    )["data"]["repository"]["pullRequests"]["edges"]
+    return prs
+
+
 
 def add_items_to_project(project_id: str, items: list[dict]) -> None:
     """
@@ -184,13 +204,12 @@ def main(
             issues = get_issues(repo, issue_label, num_items)
             # add issues to the project
             add_items_to_project(project_id, issues)
-        # for each pr label
-        for pr_label in pr_labels:
-            print(f"Processing PR label: {pr_label}...\n")
-            # get the list of PRs for the repo and label
-            prs = get_issues(repo, pr_label, num_items)
-            # add PRs to the project
-            add_items_to_project(project_id, prs)
+
+        # TODO: add back label filtering
+        # get the list of PRs for the repo and label
+        prs = get_prs(repo, num_items)
+        # add PRs to the project
+        add_items_to_project(project_id, prs)
 
 
 # run script


### PR DESCRIPTION
closes #31 

some notable things:

- see linked issue, can't `filterBy` PRs for some reason
- hit a 503 while testing, should add retry logic and whatnot 
- simply adds last 100 PRs for each repo on a schedule, should be fine 