### PR TITLE
add "Refinement" and "more_information_needed" labels into triage issue automation

### DIFF
--- a/scripts/core-triage/project.py
+++ b/scripts/core-triage/project.py
@@ -24,6 +24,8 @@ ISSUE_LABELS = [
     "bug",
     "good_first_issue",
     "awaiting_response",
+    "more_information_needed",
+    "Refinement",
     "support_rotation",
     "help_wanted",
     "spike",


### PR DESCRIPTION
simply add those two in the list

"Refinement" in particular we want to keep an eye on in the project
