### PR TITLE
github_state -> github_output

### DIFF
--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -46,7 +46,7 @@ jobs:
           TITLE: "${{ github.event.issue.title }}"
         run: |
           issueId=$(echo -n $TITLE | awk '{print $1}' | awk -F'[][]' '{print $2}')
-          echo "issueId=${issueId}" >> $GITHUB_STATE
+          echo "issueId=${issueId}" >> $GITHUB_OUTPUT
 
   edit-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -42,7 +42,7 @@ jobs:
           TITLE: "${{ github.event.issue.title }}"
         run: |
           issueId=$(echo -n $TITLE | awk '{print $1}' | awk -F'[][]' '{print $2}')
-          echo "issueId=${issueId}" >> $GITHUB_STATE
+          echo "issueId=${issueId}" >> $GITHUB_OUTPUT
 
   transition-issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After some searching this was a case of use of the wrong var because in fact, `$GITHUB_STATE != $GITHUB_OUTPUT`