### PR TITLE
capture multiline var

### DIFF
--- a/.github/workflows/jira-creation.yml
+++ b/.github/workflows/jira-creation.yml
@@ -86,9 +86,13 @@ jobs:
     steps:
       - name: Generate Labels
         id: generate-labels
+        # Because there may be multiple labels we need to account for LABELS being a
+        # multiline var and define the end of file
         run: |
           LABELS='${{ toJSON(github.event.issue.labels.*.name) }}'
-          echo "labels=${LABELS}" >> $GITHUB_STATE
+          echo "labels<<EOF" >> $GITHUB_OUTPUT
+          echo "${LABELS}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
   add-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
With the new env vars there's also [syntax for multiline string](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings) that we need to use when looking at labels because `${{ toJSON(github.event.issue.labels.*.name) }}` is actually a multiline string.  

This change makes it so we capture all line of the string as an array we can use as a matrix later on instead of it looking just like a plain string of a single (incorrectly formatted) label.