### PR TITLE
Add `dbt-server` repo to triage process

### DIFF
--- a/scripts/core-triage/project.py
+++ b/scripts/core-triage/project.py
@@ -17,7 +17,7 @@ CORE_TEAM = "core"
 # exclude some repos (generally internal) that will cause failure
 # include some extra repos not in the team
 EXCLUDE_REPOS = ["core-team", "schemas.getdbt.com"]
-EXTRA_REPOS = ["dbt-starter-project", "jaffle_shop"]
+EXTRA_REPOS = ["dbt-starter-project", "jaffle_shop", "dbt-server"]
 # issues added by label individually; lots of duplication here
 ISSUE_LABELS = [
     "triage",


### PR DESCRIPTION
Issues opened in this repo should be (manually) assigned to @lostmygithubaccount for further triage.