### PR TITLE
[`parse-semver` Action] Replace `::set-output` command

### DIFF
--- a/parse-semver/main.py
+++ b/parse-semver/main.py
@@ -3,8 +3,8 @@ from packaging.version import parse, Version
 
 
 def set_output(name, value):
-  # The pattern is: "{name}={value}" >> $GITHUB_OUTPUT
-  os.system(f"""echo "{name}={value}" >> $GITHUB_OUTPUT""");
+    os.system(f"""echo "{name}={value}" >> $GITHUB_OUTPUT""")
+
 
 def main():
     input_version = os.environ["INPUT_VERSION"]
@@ -45,6 +45,7 @@ def main():
     set_output("pre-release-version", pre_release_version)
     set_output("pre-release", pre_release)
     set_output("is-pre-release", is_pre_release_truthy)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**Description**:
The `::set-output` command will be deprecated in the future, so we need to replace it according to this guide: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

_Chagelog_:
- Moved wrapper logic to separate function;
- Replace the `print` function with the `os.system` call so that the `echo` command will be executed in a subshell.

**Related issue**:
- #39

**Work example**:
- https://github.com/dbt-labs/dbt-core-release-test/actions/runs/3807731767/jobs/6477733506#step:4:10
- https://github.com/dbt-labs/dbt-core-release-test/actions/runs/3807802027/jobs/6477837724#step:4:10