### PR TITLE
[`py-package-info` Action] Add ability to select package index and replace `::set-output` command

### DIFF
--- a/py-package-info/action.yml
+++ b/py-package-info/action.yml
@@ -7,6 +7,9 @@ inputs:
   version:
     description: "Version to get information for"
     required: false
+  check-test-index:
+    description: "Check package info in TestPyPI"
+    required: false
 outputs:
   name:
     description: "Package name"

--- a/py-package-info/action.yml
+++ b/py-package-info/action.yml
@@ -10,6 +10,7 @@ inputs:
   check-test-index:
     description: "Check package info in TestPyPI"
     required: false
+    default: "false"
 outputs:
   name:
     description: "Package name"

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -26,7 +26,7 @@ class PackageInfo:
     checksum_type: Optional[str]
 
 
-def setOutput(name, value):
+def set_output(name, value):
     os.system(f"""echo "{name}={value}" >> $GITHUB_OUTPUT""")
 
 
@@ -108,15 +108,15 @@ def main():
     print(f"source-checksum-type={package_info.checksum_type}")
     print("::endgroup::")
 
-    setOutput("name", package_info.name)
-    setOutput("version", package_info.version)
-    setOutput("homepage", package_info.homepage)
-    setOutput("summary", package_info.summary)
-    setOutput("author", package_info.author)
-    setOutput("author-email", package_info.author_email)
-    setOutput("source-url", package_info.url)
-    setOutput("source-checksum", package_info.checksum)
-    setOutput("source-checksum-type", package_info.checksum_type)  # noqa
+    set_output("name", package_info.name)
+    set_output("version", package_info.version)
+    set_output("homepage", package_info.homepage)
+    set_output("summary", package_info.summary)
+    set_output("author", package_info.author)
+    set_output("author-email", package_info.author_email)
+    set_output("source-url", package_info.url)
+    set_output("source-checksum", package_info.checksum)
+    set_output("source-checksum-type", package_info.checksum_type)  # noqa
 
 
 if __name__ == "__main__":

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -27,15 +27,17 @@ class PackageInfo:
 
 
 def setOutput(name, value):
-  os.system(f"""echo "{name}={value}" >> $GITHUB_OUTPUT""");
+    os.system(f"""echo "{name}={value}" >> $GITHUB_OUTPUT""")
 
 
-def lookup_package(name, version=None, check_test_index=None):
+def lookup_package(name, check_test_index, version=None):
     pkg_data = None
-    
-    package_index_url = "https://pypi.io/pypi/{}/json";
+
+    package_index_url = "https://pypi.io/pypi/{}/json"
     if check_test_index:
         package_index_url = "https://test.pypi.org/pypi/{}/json"
+
+    print(f"::debug::Checking the following package index {package_index_url}")
 
     with closing(urlopen(package_index_url.format(name))) as f:
         reader = codecs.getreader("utf-8")
@@ -89,9 +91,10 @@ def lookup_package(name, version=None, check_test_index=None):
 def main():
     package = os.environ["INPUT_PACKAGE"]
     version = os.environ["INPUT_VERSION"]
-    check_test_index = os.environ["INPUT_CHECK-TEST-INDEX"]
+    check_test_index = os.environ["INPUT_CHECK-TEST-INDEX"] == "true"
 
-    package_info = PackageInfo(**lookup_package(package, version=version, check_test_index=check_test_index))
+    package_info = PackageInfo(
+        **lookup_package(package, check_test_index, version=version))
 
     print("::group::Python Package Info Outputs")
     print(f"name={package_info.name}")

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -26,9 +26,18 @@ class PackageInfo:
     checksum_type: Optional[str]
 
 
-def lookup_package(name, version=None):
+def setOutput(name, value):
+  os.system(f"""echo "{name}={value}" >> $GITHUB_OUTPUT""");
+
+
+def lookup_package(name, version=None, check_test_index=None):
     pkg_data = None
-    with closing(urlopen("https://pypi.io/pypi/{}/json".format(name))) as f:
+    
+    package_index_url = "https://pypi.io/pypi/{}/json";
+    if check_test_index:
+        package_index_url = "https://test.pypi.org/pypi/{}/json"
+
+    with closing(urlopen(package_index_url.format(name))) as f:
         reader = codecs.getreader("utf-8")
         pkg_data = json.load(reader(f))
     if pkg_data is None:
@@ -80,8 +89,9 @@ def lookup_package(name, version=None):
 def main():
     package = os.environ["INPUT_PACKAGE"]
     version = os.environ["INPUT_VERSION"]
+    check_test_index = os.environ["INPUT_CHECK-TEST-INDEX"]
 
-    package_info = PackageInfo(**lookup_package(package, version=version))
+    package_info = PackageInfo(**lookup_package(package, version=version, check_test_index=check_test_index))
 
     print("::group::Python Package Info Outputs")
     print(f"name={package_info.name}")
@@ -95,15 +105,15 @@ def main():
     print(f"source-checksum-type={package_info.checksum_type}")
     print("::endgroup::")
 
-    print(f"::set-output name=name::{package_info.name}")
-    print(f"::set-output name=version::{package_info.version}")
-    print(f"::set-output name=homepage::{package_info.homepage}")
-    print(f"::set-output name=summary::{package_info.summary}")
-    print(f"::set-output name=author::{package_info.author}")
-    print(f"::set-output name=author-email::{package_info.author_email}")
-    print(f"::set-output name=source-url::{package_info.url}")
-    print(f"::set-output name=source-checksum::{package_info.checksum}")
-    print(f"::set-output name=source-checksum-type::{package_info.checksum_type}")  # noqa
+    setOutput("name", package_info.name)
+    setOutput("version", package_info.version)
+    setOutput("homepage", package_info.homepage)
+    setOutput("summary", package_info.summary)
+    setOutput("author", package_info.author)
+    setOutput("author-email", package_info.author_email)
+    setOutput("source-url", package_info.url)
+    setOutput("source-checksum", package_info.checksum)
+    setOutput("source-checksum-type", package_info.checksum_type)  # noqa
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description**:
We are working on the release workflow for `dbt` packages. When the workflow runs in [test mode](https://github.com/dbt-labs/dbt-release/blob/b5cc5b5f1291c3e85fddc60a3379b97936551366/.github/workflows/pypi-release.yml#L94-L110), the package will be uploaded to the [test python package index](https://packaging.python.org/en/latest/guides/using-testpypi/). So we need to update the `py-package-info` GH action to provide an ability to select package index to fetch package info. Also, the `::set-output` command will be deprecated in the future, so we need to replace it according to this guide: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

_Chagelog_:
- Add `check-test-index` input to check package info in the test package index. By default, we check the real index;
- Update `py-package-info` logic to respect `check-test-index` input;
- Replace the `::set-output` command since would be deprecated in the feature;

**Related issue(s)**:
- #39

**Work example**:
- https://github.com/dbt-labs/dbt-snowflake-release-test/actions/runs/3807741361/jobs/6477812040#step:3:9
- https://github.com/dbt-labs/dbt-snowflake-release-test/actions/runs/3807741361/jobs/6477812261#step:3:9
- https://github.com/dbt-labs/dbt-core-release-test/actions/runs/3807731767/jobs/6477772474#step:3:9
- https://github.com/dbt-labs/dbt-core-release-test/actions/runs/3807802027/jobs/6477854729#step:3:9

**Local testing**:

_Case №1 - `INPUT_CHECK-TEST-INDEX` set to `false`_:
Environment variables:
```powershell
[System.Environment]::SetEnvironmentVariable('INPUT_PACKAGE','dbt-core')
[System.Environment]::SetEnvironmentVariable('INPUT_VERSION','1.4.1b')
[System.Environment]::SetEnvironmentVariable('INPUT_CHECK-TEST-INDEX','false')
```
Output:
```console
::debug::Checking the following package index https://pypi.io/pypi/{}/json
::warning::Could not find an exact version match for dbt-core version 1.4.1b; using newest instead
::debug::Using provided checksum for dbt-core
::group::Python Package Info Outputs
name=dbt-core
version=1.3.1
homepage=https://github.com/dbt-labs/dbt-core
summary=With dbt, data analysts and engineers can build analytics the way engineers build applications.
author=dbt Labs
author-email=info@dbtlabs.com
source-url=https://files.pythonhosted.org/packages/ae/a0/f2d8daaabe71c394722bfca4bd9f2818fe095fe7a99d022abd32f1e6c61a/dbt-core-1.3.1.tar.gz
source-checksum=5b46c1dd21dde6ed160a14b781f7c34e07ca0de321fe317d682c84f62cdcb802
source-checksum-type=sha256
::endgroup::
```

_Case №2 - `INPUT_CHECK-TEST-INDEX` set to `true`_:
Environment variables:
```powershell
[System.Environment]::SetEnvironmentVariable('INPUT_PACKAGE','dbt-core')
[System.Environment]::SetEnvironmentVariable('INPUT_VERSION','1.4.1b')
[System.Environment]::SetEnvironmentVariable('INPUT_CHECK-TEST-INDEX','true')
```
Output:
```console
::debug::Checking the following package index https://test.pypi.org/pypi/{}/json
::warning::Could not find an exact version match for dbt-core version 1.4.1b; using newest instead
::debug::Using provided checksum for dbt-core
::group::Python Package Info Outputs
name=dbt-core
version=0.16.1
homepage=https://github.com/fishtown-analytics/dbt
summary=dbt (data build tool) is a command line tool that helps analysts and engineers transform data in their warehouse more effectively
author=Fishtown Analytics
author-email=info@fishtownanalytics.com
source-url=https://test-files.pythonhosted.org/packages/a6/d9/82a91e133ff144ded184fc9d99760d9d520270c9be1920ce729720172a76/dbt-core-0.16.1.tar.gz
source-checksum=249e838a6d78be13c3bc8eb1295e1139e0359b9a7ab0b464ab0c9107346ed133
source-checksum-type=sha256
::endgroup::
```