### PR TITLE
[`py-package-info` Action] Introduce retry logic

### DIFF
--- a/py-package-info/action.yml
+++ b/py-package-info/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Check package info in TestPyPI"
     required: false
     default: "false"
+  retry-count:
+    description: "How many attempts before failure"
+    required: false
+    default: "3"
 outputs:
   name:
     description: "Package name"

--- a/py-package-info/action.yml
+++ b/py-package-info/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: "Check package info in TestPyPI"
     required: false
     default: "false"
-  retry-count:
+  attempts-count:
     description: "How many attempts before failure"
     required: false
     default: "3"

--- a/py-package-info/action.yml
+++ b/py-package-info/action.yml
@@ -11,8 +11,8 @@ inputs:
     description: "Check package info in TestPyPI"
     required: false
     default: "false"
-  attempts-count:
-    description: "How many attempts before failure"
+  retries:
+    description: "How many retries before failure"
     required: false
     default: "3"
 outputs:

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -138,7 +138,7 @@ def lookup_package(name, check_test_index, version=None, attempts_limit=3):
                 else:
                     package_info['version'] = version
         except Exception as e:
-            print(f"::warning::Exception occurred: {type(e).__name__} - {e}")
+            print(f"Exception occurred: {type(e).__name__} - {e}. Retrying.")
             if attempt == attempts_limit - 1 and not isinstance(e, PackageVersionNotFoundInPyPIError):
                 raise RuntimeError(f"{e}")
             back_off = get_exponential_backoff_in_seconds(attempt)

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -138,13 +138,16 @@ def lookup_package(name, check_test_index, version=None, attempts_limit=3):
                 else:
                     package_info['version'] = version
         except Exception as e:
-            print(f"Exception occurred: {type(e).__name__} - {e}. Retrying.")
             if attempt == attempts_limit - 1 and not isinstance(e, PackageVersionNotFoundInPyPIError):
                 raise RuntimeError(f"{e}")
-            back_off = get_exponential_backoff_in_seconds(attempt)
-            print(f"::debug::Sleep for {back_off} seconds before next attempt")
-            time.sleep(back_off)
-            continue
+            elif attempt < attempts_limit - 1:
+                print(
+                    f"Exception occurred: {type(e).__name__} - {e}. Retrying.")
+                back_off = get_exponential_backoff_in_seconds(attempt)
+                print(
+                    f"::debug::Sleep for {back_off} seconds before next attempt")
+                time.sleep(back_off)
+                continue
         break
 
     if artifact is None:

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -2,6 +2,7 @@ import codecs
 import json
 import os
 import pkg_resources
+import time
 from contextlib import closing
 from dataclasses import dataclass
 from typing import Optional
@@ -30,8 +31,41 @@ def set_output(name, value):
     os.system(f"""echo "{name}={value}" >> $GITHUB_OUTPUT""")
 
 
-def lookup_package(name, check_test_index, version=None):
-    pkg_data = None
+def get_exponential_backoff_in_seconds(attempt_number: int) -> int:
+    """
+    Returns exponential back-off - depending on number of attempt.
+    Considers that `attempt_number` starts from 0.
+    Initial delay - 4 second.
+    """
+
+    return pow(attempt_number + 2, 2)
+
+
+def fetch_package_data(name, package_index_url):
+    metadata = None
+
+    with closing(urlopen(package_index_url.format(name))) as f:
+        reader = codecs.getreader("utf-8")
+        metadata = json.load(reader(f))
+
+    return metadata
+
+
+def get_package_info(package_metadata):
+    info = {}
+    info['name'] = package_metadata['info']['name']
+    info['version'] = package_metadata['info'].get('version', '')
+    info['homepage'] = package_metadata['info'].get('home_page', '')
+    info['summary'] = package_metadata['info'].get('summary', '')
+    info['author'] = package_metadata['info'].get('author', '')
+    info['author_email'] = package_metadata['info'].get('author_email', '')
+    return info
+
+
+def lookup_package(name, check_test_index, version=None, attempts_limit=3):
+    package_metadata = None
+    package_info = {}
+    artifact = None
 
     package_index_url = "https://pypi.io/pypi/{}/json"
     if check_test_index:
@@ -39,62 +73,75 @@ def lookup_package(name, check_test_index, version=None):
 
     print(f"::debug::Checking the following package index {package_index_url}")
 
-    with closing(urlopen(package_index_url.format(name))) as f:
-        reader = codecs.getreader("utf-8")
-        pkg_data = json.load(reader(f))
-    if pkg_data is None:
-        raise RuntimeError(f"no package data for: {name}")
-    d = {}
-    d['name'] = pkg_data['info']['name']
-    d['version'] = pkg_data['info'].get('version', '')
-    d['homepage'] = pkg_data['info'].get('home_page', '')
-    d['summary'] = pkg_data['info'].get('summary', '')
-    d['author'] = pkg_data['info'].get('author', '')
-    d['author_email'] = pkg_data['info'].get('author_email', '')
-    artifact = None
-    if version:
-        for pypi_version in pkg_data['releases']:
-            if pkg_resources.safe_version(pypi_version) == version:
-                for version_artifact in pkg_data['releases'][pypi_version]:
-                    if version_artifact['packagetype'] == 'sdist':
-                        artifact = version_artifact
-                        d['version'] = version
-                        break
-        if artifact is None:
-            print("::warning::Could not find an exact version match for "
-                  f"{name} version {version}; using newest instead")
+    for attempt in range(attempts_limit):
+        print(
+            f"::debug::Fetching package metadata - attempt {attempt + 1} / {attempts_limit}")
+
+        try:
+            package_metadata = fetch_package_data(name, package_index_url)
+
+            if package_metadata is None:
+                raise RuntimeError(f"No package data for: {name}")
+
+            package_info = get_package_info(package_metadata)
+
+            if version:
+                for pypi_version in package_metadata['releases']:
+                    if pkg_resources.safe_version(pypi_version) == version:
+                        for version_artifact in package_metadata['releases'][pypi_version]:
+                            if version_artifact['packagetype'] == 'sdist':
+                                artifact = version_artifact
+                                package_info['version'] = version
+                                break
+                if artifact is None:
+                    print("::warning::Could not find an exact version match for "
+                          f"{name} version {version}. Retrying.")
+                    raise RuntimeError("Could not find an exact version match for "
+                                       f"{name} version {version}. Retrying.")
+        except:
+            if attempt < attempts_limit:
+                sleep = get_exponential_backoff_in_seconds(attempt)
+                print(f"::debug::Sleep for {sleep} seconds")
+                time.sleep(sleep)
+                continue
+
+        break
+
+    print("::warning::Could not find an exact version match for "
+          f"{name} version {version}; using newest instead")
 
     if artifact is None:  # no version given or exact match not found
-        for url in pkg_data['urls']:
+        for url in package_metadata['urls']:
             if url['packagetype'] == 'sdist':
                 artifact = url
                 break
 
     if artifact:
-        d['url'] = artifact['url']
+        package_info['url'] = artifact['url']
         if 'digests' in artifact and 'sha256' in artifact['digests']:
             print(f"::debug::Using provided checksum for {name}")
-            d['checksum'] = artifact['digests']['sha256']
+            package_info['checksum'] = artifact['digests']['sha256']
         else:
             print(f"::debug::Fetching sdist to compute checksum for {name}")
             with closing(urlopen(artifact['url'])) as f:
-                d['checksum'] = sha256(f.read()).hexdigest()
+                package_info['checksum'] = sha256(f.read()).hexdigest()
             print(f"::debug::Done fetching {name}")
     else:  # no sdist found
-        d['url'] = ''
-        d['checksum'] = ''
+        package_info['url'] = ''
+        package_info['checksum'] = ''
         print("::warning::No sdist found for {name}")
-    d['checksum_type'] = 'sha256'
-    return d
+    package_info['checksum_type'] = 'sha256'
+    return package_info
 
 
 def main():
     package = os.environ["INPUT_PACKAGE"]
     version = os.environ["INPUT_VERSION"]
     check_test_index = os.environ["INPUT_CHECK-TEST-INDEX"] == "true"
+    retry_count = int(os.environ["INPUT_RETRY-COUNT"])
 
     package_info = PackageInfo(
-        **lookup_package(package, check_test_index, version=version))
+        **lookup_package(package, check_test_index, version=version, attempts_limit=retry_count))
 
     print("::group::Python Package Info Outputs")
     print(f"name={package_info.name}")

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -140,7 +140,7 @@ def lookup_package(name, check_test_index, version=None, attempts_limit=3):
         except Exception as e:
             if attempt == attempts_limit - 1 and not isinstance(e, PackageVersionNotFoundInPyPIError):
                 raise RuntimeError(f"{e}")
-            elif attempt < attempts_limit - 1:
+            if attempt < attempts_limit - 1:
                 print(
                     f"Exception occurred: {type(e).__name__} - {e}. Retrying.")
                 back_off = get_exponential_backoff_in_seconds(attempt)

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -168,10 +168,10 @@ def main():
     package = os.environ["INPUT_PACKAGE"]
     version = os.environ["INPUT_VERSION"]
     check_test_index = os.environ["INPUT_CHECK-TEST-INDEX"] == "true"
-    retry_count = int(os.environ["INPUT_RETRY-COUNT"])
+    attempts_count = int(os.environ["INPUT_ATTEMPTS-COUNT"]) + 1
 
     package_info = PackageInfo(
-        **lookup_package(package, check_test_index, version=version, attempts_limit=retry_count))
+        **lookup_package(package, check_test_index, version=version, attempts_limit=attempts_count))
 
     print("::group::Python Package Info Outputs")
     print(f"name={package_info.name}")

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -168,7 +168,7 @@ def main():
     package = os.environ["INPUT_PACKAGE"]
     version = os.environ["INPUT_VERSION"]
     check_test_index = os.environ["INPUT_CHECK-TEST-INDEX"] == "true"
-    attempts_count = int(os.environ["INPUT_ATTEMPTS-COUNT"]) + 1
+    attempts_count = int(os.environ["INPUT_RETRIES"]) + 1
 
     package_info = PackageInfo(
         **lookup_package(package, check_test_index, version=version, attempts_limit=attempts_count))


### PR DESCRIPTION
**Description**:
This pr introduces retry logic for the `py-package-info` GH  action. This logic should help to cover the following scenarios:
- Intermittent network issues when fetching metadata from PyPI;
- Checking the availability of a new version of the package during the release process;

_Retry logic strategy_:
- Try fetching package metadata;
- If the action didn't manage to fetch package metadata - raise an exception and retry;
- If the action managed to fetch package metadata, but version validation failed - raise an exception and retry;
- If, after several attempts action didn't manage to fetch package metadata - raise an error;
- If, after several attempts, version validation is not passed  - try to use the newest version available; 

**Changelog**:
- Added `retries` input;
- Refactored existing logic;
- Implemented retry logic;
- Improved logging;
- Introduced custom exceptions;

**Testing**:
Test case №1: Version `1.4.1b2` doesn't exist in test package index

_Inputs_:
```pwsh
[System.Environment]::SetEnvironmentVariable('INPUT_PACKAGE','dbt-core')
[System.Environment]::SetEnvironmentVariable('INPUT_VERSION','1.4.1b2')
[System.Environment]::SetEnvironmentVariable('INPUT_CHECK-TEST-INDEX','true')
[System.Environment]::SetEnvironmentVariable('INPUT_RETRIES','2')
```

_Action logs_:
```console
::debug::Checking the following package index https://test.pypi.org/pypi/{}/json::debug::Fetching package metadata - attempt 1 / 3
::debug::Fetching metadata for dbt-core from https://test.pypi.org/pypi/dbt-core/json::debug::Done fetching metadataException occurred: PackageVersionNotFoundInPyPIError - Could not find an exact version match for dbt-core version 1.4.1b2. Retrying.::debug::Sleep for 4 seconds before next attempt::debug::Fetching package metadata - attempt 2 / 3::debug::Fetching metadata for dbt-core from https://test.pypi.org/pypi/dbt-core/json::debug::Done fetching metadataException occurred: PackageVersionNotFoundInPyPIError - Could not find an exact version match for dbt-core version 1.4.1b2. Retrying.
::debug::Sleep for 9 seconds before next attempt
::debug::Fetching package metadata - attempt 3 / 3
::debug::Fetching metadata for dbt-core from https://test.pypi.org/pypi/dbt-core/json
::debug::Done fetching metadata
Exception occurred: PackageVersionNotFoundInPyPIError - Could not find an exact version match for dbt-core version 1.4.1b2. Retrying.
::debug::Sleep for 16 seconds before next attempt
::warning::Could not find an exact version match for dbt-core version 1.4.1b2 after 3 attempts. Using newest version instead.
::debug::Using provided checksum for dbt-core
::group::Python Package Info Outputs
name=dbt-core
version=0.16.1
homepage=https://github.com/fishtown-analytics/dbt
summary=dbt (data build tool) is a command line tool that helps analysts and engineers transform data in their warehouse more effectively
author=Fishtown Analytics
author-email=info@fishtownanalytics.com
source-url=https://test-files.pythonhosted.org/packages/a6/d9/82a91e133ff144ded184fc9d99760d9d520270c9be1920ce729720172a76/dbt-core-0.16.1.tar.gz
source-checksum=249e838a6d78be13c3bc8eb1295e1139e0359b9a7ab0b464ab0c9107346ed133
source-checksum-type=sha256
::endgroup::
```

Test case №2: Version `1.4.1b1` exists in test package index

_Inputs_:
```pwsh
[System.Environment]::SetEnvironmentVariable('INPUT_PACKAGE','dbt-core')
[System.Environment]::SetEnvironmentVariable('INPUT_VERSION','1.4.1b1')
[System.Environment]::SetEnvironmentVariable('INPUT_CHECK-TEST-INDEX','true')
[System.Environment]::SetEnvironmentVariable('INPUT_RETRIES','2')
```

_Action logs_:
```console
::debug::Checking the following package index https://test.pypi.org/pypi/{}/json
::debug::Fetching package metadata - attempt 1 / 3
::debug::Fetching metadata for dbt-core from https://test.pypi.org/pypi/dbt-core/json
::debug::Done fetching metadata
::debug::Using provided checksum for dbt-core
::group::Python Package Info Outputs
name=dbt-core
version=1.4.1b1
homepage=https://github.com/fishtown-analytics/dbt
summary=dbt (data build tool) is a command line tool that helps analysts and engineers transform data in their warehouse more effectively
author=Fishtown Analytics
author-email=info@fishtownanalytics.com
source-url=https://test-files.pythonhosted.org/packages/6f/a0/1fde82166ccf40191de0d21d3f161b4a36684b3492468d93a9ebb0e8b56b/dbt-core-1.4.1b1.tar.gz
source-checksum=63cec75abf826a24407d7b0bdc2191f842e2abc107b658db41b0d9686f414f08
source-checksum-type=sha256
::endgroup::
```

Test case №3: The `dbt-core-test` package doesn't exist in test package index.
_Inputs_:
```pwsh
[System.Environment]::SetEnvironmentVariable('INPUT_PACKAGE','dbt-core-test')
[System.Environment]::SetEnvironmentVariable('INPUT_VERSION','1.4.1b1')
[System.Environment]::SetEnvironmentVariable('INPUT_CHECK-TEST-INDEX','true')
[System.Environment]::SetEnvironmentVariable('INPUT_RETRIES','4')
```

_Action logs_:
```console
::debug::Checking the following package index https://test.pypi.org/pypi/{}/json
::debug::Fetching package metadata - attempt 1 / 5
Exception occurred: HTTPError - HTTP Error 404: Not Found. Retrying.
::debug::Sleep for 4 seconds before next attempt
::debug::Fetching package metadata - attempt 2 / 5
Exception occurred: HTTPError - HTTP Error 404: Not Found. Retrying.
::debug::Sleep for 9 seconds before next attempt
::debug::Fetching package metadata - attempt 3 / 5
Exception occurred: HTTPError - HTTP Error 404: Not Found. Retrying.
::debug::Sleep for 16 seconds before next attempt
::debug::Fetching package metadata - attempt 4 / 5
Exception occurred: HTTPError - HTTP Error 404: Not Found. Retrying.
::debug::Sleep for 25 seconds before next attempt
::debug::Fetching package metadata - attempt 5 / 5
Exception occurred: HTTPError - HTTP Error 404: Not Found. Retrying.
Traceback (most recent call last):
  ...
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\@Sources\GitHub\actions\py-package-info\main.py", line 200, in <module>
    main()
  File "D:\@Sources\GitHub\actions\py-package-info\main.py", line 174, in main
    **lookup_package(package, check_test_index, version=version, attempts_limit=attempts_count))
  File "D:\@Sources\GitHub\actions\py-package-info\main.py", line 143, in lookup_package
    raise RuntimeError(f"{e}")
RuntimeError: HTTP Error 404: Not Found
```
