### PR TITLE
update gh action set-output variables

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set branch value
         id: variables
         run: |
-          echo "::set-output name=BRANCH_NAME::prep-release/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID"
+          echo "BRANCH_NAME=prep-release/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Create PR branch
         run: |


### PR DESCRIPTION
Update deprecated github actions output variables according to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/