### PR TITLE
[CI/CD] Implement slack notifications for `test-dbt-installation-*` workflows

### DIFF
--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -157,24 +157,15 @@ jobs:
           path: ${{ steps.job-status.outputs.path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  get-jobs-status:
-    name: "Check Job Statuses"
+  send-slack-notification:
     needs: [generate-artifact-name, docker-installation-test]
-    if: ${{ failure() && github.event_name == 'schedule'  }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:
       artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
-
-  slack-notification:
-    name: "Post Scheduled Run Failures"
-    needs: get-jobs-status
-    if: ${{ failure() && github.event_name == 'schedule' }}
-
-    uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
-    with:
-      status: "failure"
-      notification_title: "Docker nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
+      installation_method: "Docker"
+      package_name: ${{ inputs.package_name }}
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -39,8 +39,24 @@ permissions:
 env:
   GITHUB_PACKAGES_LINK: "ghcr.io"
   NOTIFICATION_PREFIX: "[Docker Installation Tests]"
+  ARTIFACT_BASENAME: "docker-installation-test"
+  ARTIFACT_RETENTION_DAYS: 1
 
 jobs:
+  generate-artifact-name:
+    runs-on: ubuntu-latest
+
+    outputs:
+      artifact-name: ${{ steps.artifact-name.outputs.name }}
+
+    steps:
+      - name: "Generate Artifact Name"
+        id: artifact-name
+        run: |
+          date=$(date +'%m%d%Y')
+          name="${{ env.ARTIFACT_BASENAME }}-$date"
+          echo "name=$name" >> $GITHUB_OUTPUT
+
   fetch-container-tags:
     runs-on: ubuntu-latest
 
@@ -85,7 +101,7 @@ jobs:
 
   docker-installation-test:
     runs-on: ubuntu-latest
-    needs: fetch-container-tags
+    needs: [fetch-container-tags, generate-artifact-name]
 
     strategy:
       fail-fast: false
@@ -93,6 +109,10 @@ jobs:
         tag: ${{ fromJSON(needs.fetch-container-tags.outputs.latest-tags) }}
 
     steps:
+      - name: "Fail Job"
+        run: |
+          exit 1
+
       - name: "Resolve Image Ref"
         id: image-info
         run: |
@@ -119,15 +139,46 @@ jobs:
           image: ${{ steps.image-info.outputs.ref }}
           run: dbt --version
 
+      - name: "Dump Job Status"
+        if: ${{ always() }}
+        id: job-status
+        run: |
+          file="test-${{ strategy.job-index }}-tag-${{ matrix.tag }}.json"
+          # Create file
+          touch $file 
+          # Write job status to file
+          echo $JOB_STATUS >> $file
+          # Set path to file for subsequent steps          
+          echo "path=$file" >> $GITHUB_OUTPUT
+        env:
+          JOB_STATUS: ${{ toJson(job.status) }}
+
+      - name: "Upload Job Status"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+          path: ${{ steps.job-status.outputs.path }}
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  get-jobs-status:
+    name: "Check Job Statuses"
+    needs: [generate-artifact-name, docker-installation-test]
+    if: ${{ failure() }}
+
+    uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+    with:
+      artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+
   slack-notification:
     name: "Post Scheduled Run Failures"
-    needs: docker-installation-test
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: get-jobs-status
+    if: ${{ failure() }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
       status: "failure"
-      notification_title: "Docker nightly integration test failed for - ${{ inputs.package_name }}"
+      notification_title: "Docker nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}

--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -149,7 +149,7 @@ jobs:
         env:
           JOB_STATUS: ${{ toJson(job.status) }}
 
-      - name: "Upload Job Status"
+      - name: "Upload Job Status For Slack Notification"
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -109,10 +109,6 @@ jobs:
         tag: ${{ fromJSON(needs.fetch-container-tags.outputs.latest-tags) }}
 
     steps:
-      - name: "Fail Job"
-        run: |
-          exit 1
-
       - name: "Resolve Image Ref"
         id: image-info
         run: |
@@ -164,7 +160,7 @@ jobs:
   get-jobs-status:
     name: "Check Job Statuses"
     needs: [generate-artifact-name, docker-installation-test]
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule'  }}
 
     uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
     with:
@@ -173,7 +169,7 @@ jobs:
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: get-jobs-status
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
@@ -181,4 +177,4 @@ jobs:
       notification_title: "Docker nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -162,7 +162,7 @@ jobs:
     needs: [generate-artifact-name, docker-installation-test]
     if: ${{ failure() && github.event_name == 'schedule'  }}
 
-    uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+    uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:
       artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
 

--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -101,7 +101,7 @@ jobs:
         env:
           JOB_STATUS: ${{ toJson(job.status) }}
 
-      - name: "Upload Job Status"
+      - name: "Upload Job Status For Slack Notification"
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -114,7 +114,7 @@ jobs:
     needs: [generate-artifact-name, homebrew-installation-test]
     if: ${{ failure() && github.event_name == 'schedule' }}
 
-    uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+    uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:
       artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
 

--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -34,11 +34,34 @@ on:
 permissions:
   contents: read # required for slack-post-notification workflow
 
+env:
+  ARTIFACT_BASENAME: "homebrew-installation-test"
+  ARTIFACT_RETENTION_DAYS: 1
+
 jobs:
-  homebrew-integration-test:
-    runs-on: macos-11
+  generate-artifact-name:
+    runs-on: ubuntu-latest
+
+    outputs:
+      artifact-name: ${{ steps.artifact-name.outputs.name }}
 
     steps:
+      - name: "Generate Artifact Name"
+        id: artifact-name
+        run: |
+          date=$(date +'%m%d%Y')
+          name="${{ env.ARTIFACT_BASENAME }}-$date"
+          echo "name=$name" >> $GITHUB_OUTPUT
+
+  homebrew-integration-test:
+    runs-on: macos-11
+    needs: generate-artifact-name
+
+    steps:
+      - name: "Fail Job"
+        run: |
+          exit 1
+
       - name: "Prepare Brew"
         # brew upgrade generates some symlink update warnings that cause failures without the || true.
         # They're just that the symlink wasn't updated which is okay to ignore.
@@ -68,15 +91,46 @@ jobs:
         run: |
           dbt --version
 
+      - name: "Dump Job Status"
+        if: ${{ always() }}
+        id: job-status
+        run: |
+          file="test-${{ inputs.package_name }}.json"
+          # Create file
+          touch $file 
+          # Write job status to file
+          echo $JOB_STATUS >> $file
+          # Set path to file for subsequent steps          
+          echo "path=$file" >> $GITHUB_OUTPUT
+        env:
+          JOB_STATUS: ${{ toJson(job.status) }}
+
+      - name: "Upload Job Status"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+          path: ${{ steps.job-status.outputs.path }}
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  get-jobs-status:
+    name: "Check Job Statuses"
+    needs: [generate-artifact-name, homebrew-integration-test]
+    if: ${{ failure() }}
+
+    uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+    with:
+      artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+
   slack-notification:
     name: "Post Scheduled Run Failures"
-    needs: homebrew-integration-test
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: get-jobs-status
+    if: ${{ failure() }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
       status: "failure"
-      notification_title: "Homebrew nightly integration test failed for - ${{ inputs.package_name }}"
+      notification_title: "Homebrew nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}

--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -109,24 +109,15 @@ jobs:
           path: ${{ steps.job-status.outputs.path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  get-jobs-status:
-    name: "Check Job Statuses"
+  send-slack-notification:
     needs: [generate-artifact-name, homebrew-installation-test]
     if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:
       artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
-
-  slack-notification:
-    name: "Post Scheduled Run Failures"
-    needs: get-jobs-status
-    if: ${{ failure() && github.event_name == 'schedule' }}
-
-    uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
-    with:
-      status: "failure"
-      notification_title: "Homebrew nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
+      installation_method: "Homebrew"
+      package_name: ${{ inputs.package_name }}
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -53,7 +53,7 @@ jobs:
           name="${{ env.ARTIFACT_BASENAME }}-$date"
           echo "name=$name" >> $GITHUB_OUTPUT
 
-  homebrew-integration-test:
+  homebrew-installation-test:
     runs-on: macos-11
     needs: generate-artifact-name
 
@@ -115,7 +115,7 @@ jobs:
 
   get-jobs-status:
     name: "Check Job Statuses"
-    needs: [generate-artifact-name, homebrew-integration-test]
+    needs: [generate-artifact-name, homebrew-installation-test]
     if: ${{ failure() }}
 
     uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml

--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -58,10 +58,6 @@ jobs:
     needs: generate-artifact-name
 
     steps:
-      - name: "Fail Job"
-        run: |
-          exit 1
-
       - name: "Prepare Brew"
         # brew upgrade generates some symlink update warnings that cause failures without the || true.
         # They're just that the symlink wasn't updated which is okay to ignore.
@@ -116,7 +112,7 @@ jobs:
   get-jobs-status:
     name: "Check Job Statuses"
     needs: [generate-artifact-name, homebrew-installation-test]
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
     with:
@@ -125,7 +121,7 @@ jobs:
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: get-jobs-status
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
@@ -133,4 +129,4 @@ jobs:
       notification_title: "Homebrew nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-main.yml
+++ b/.github/workflows/test-dbt-installation-main.yml
@@ -31,7 +31,7 @@ on:
 
   # run this once per night to ensure no regressions
   schedule:
-    - cron: "0 9 * * *" # 9:00 UTC
+    - cron: "0 9,13,18 * * *" # 9:00, 13:00, 18:00 UTC
 
 jobs:
   dbt-installation-homebrew:

--- a/.github/workflows/test-dbt-installation-main.yml
+++ b/.github/workflows/test-dbt-installation-main.yml
@@ -28,8 +28,8 @@ on:
           - "source"
 
   # run this once per night to ensure no regressions
-  # schedule:
-  #   - cron: "0 9,13,18 * * *" # 9:00, 13:00, 18:00 UTC
+  schedule:
+    - cron: "0 9 * * *" # 9:00 UTC
 
 jobs:
   dbt-installation-homebrew:

--- a/.github/workflows/test-dbt-installation-main.yml
+++ b/.github/workflows/test-dbt-installation-main.yml
@@ -1,6 +1,8 @@
 # **what?**
+# Launch all dbt installations tests from one workflow
 
 # **why?**
+# Simplify the process of launching and tracking of installations tests
 
 # **when?**
 # This workflow will run on a schedule every night and also can be
@@ -34,8 +36,9 @@ on:
 jobs:
   dbt-installation-homebrew:
     if: >-
-      inputs.test-installation-method == 'all'
-      || inputs.test-installation-method == 'homebrew'
+      github.event_name == 'schedule'
+      || (inputs.test-installation-method == 'all'
+      || inputs.test-installation-method == 'homebrew')
 
     strategy:
       fail-fast: false
@@ -51,8 +54,9 @@ jobs:
 
   dbt-installation-pip:
     if: >-
-      inputs.test-installation-method == 'all'
-      || inputs.test-installation-method == 'pip'
+      github.event_name == 'schedule'
+      || (inputs.test-installation-method == 'all'
+      || inputs.test-installation-method == 'pip')
     strategy:
       fail-fast: false
       matrix:
@@ -73,8 +77,9 @@ jobs:
 
   dbt-installation-docker:
     if: >-
-      inputs.test-installation-method == 'all'
-      || inputs.test-installation-method == 'docker'
+      github.event_name == 'schedule'
+      || (inputs.test-installation-method == 'all'
+      || inputs.test-installation-method == 'docker')
     strategy:
       fail-fast: false
       matrix:
@@ -95,8 +100,9 @@ jobs:
 
   dbt-installation-source:
     if: >-
-      inputs.test-installation-method == 'all'
-      || inputs.test-installation-method == 'source'
+      github.event_name == 'schedule'
+      || (inputs.test-installation-method == 'all'
+      || inputs.test-installation-method == 'source')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-dbt-installation-notify-job-statuses.yml
+++ b/.github/workflows/test-dbt-installation-notify-job-statuses.yml
@@ -1,8 +1,17 @@
 # **what?**
+# Check dumps of installation test jobs to aggregate statistics
+# and send the Slack notification.
 
 # **why?**
+# A consistent way to notify about failed dbt installation test
+# and provide additional context for the notification.
 
 # **when?**
+# When dbt installation test failed.
+# This reusable workflow can be launched on call by specifying:
+#  artifact_name       - that contains jobs dump
+#  package_name        - dbt adapter/repo/container that was tested
+#  installation_method - installation method that failed
 
 name: dbt Installation - Notify Job Statuses In Slack
 

--- a/.github/workflows/test-dbt-installation-notify-job-statuses.yml
+++ b/.github/workflows/test-dbt-installation-notify-job-statuses.yml
@@ -4,7 +4,7 @@
 
 # **when?**
 
-name: dbt Installation - Verify Test Jobs Statuses
+name: dbt Installation - Notify Job Statuses In Slack 
 
 on:
   workflow_call:

--- a/.github/workflows/test-dbt-installation-notify-job-statuses.yml
+++ b/.github/workflows/test-dbt-installation-notify-job-statuses.yml
@@ -20,8 +20,8 @@ on:
         type: string
     secrets:
       SLACK_WEBHOOK_URL:
-      description: Slack app webhook url
-      required: true
+        description: Slack app webhook url
+        required: true
 
 jobs:
   get-jobs-statuses:

--- a/.github/workflows/test-dbt-installation-notify-job-statuses.yml
+++ b/.github/workflows/test-dbt-installation-notify-job-statuses.yml
@@ -4,7 +4,7 @@
 
 # **when?**
 
-name: dbt Installation - Notify Job Statuses In Slack 
+name: dbt Installation - Notify Job Statuses In Slack
 
 on:
   workflow_call:
@@ -12,18 +12,24 @@ on:
       artifact_name:
         required: true
         type: string
-    outputs:
-      job_statistics:
-        description: "Overall statistics regarding jobs statuses"
-        value: ${{ jobs.check-jobs-status.outputs.job_statistics }}
+      installation_method:
+        required: true
+        type: string
+      package_name:
+        required: true
+        type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+      description: Slack app webhook url
+      required: true
 
 jobs:
-  check-jobs-status:
+  get-jobs-statuses:
     name: "Check Job Statuses"
     runs-on: ubuntu-latest
 
     outputs:
-      job_statistics: ${{ steps.get-job_statistics.outputs.result }}
+      jobs-statuses: ${{ steps.get-job_statistics.outputs.result }}
 
     steps:
       - name: "Download Artifact ${{ inputs.artifact_name }}"
@@ -84,3 +90,15 @@ jobs:
             core.debug(job_statistics);
 
             return job_statistics;
+
+  slack-notification:
+    name: "Post Scheduled Run Failures"
+    needs: get-jobs-statuses
+
+    uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
+    with:
+      status: "failure"
+      notification_title: "${{ inputs.installation_method }} nightly installation test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-statuses.outputs.jobs-statuses }}"
+
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -149,7 +149,7 @@ jobs:
             };
 
             const jobs_statuses = {
-                failed: [],
+                failure: [],
                 success: [],
                 cancelled: [],
                 undefined: []
@@ -166,8 +166,8 @@ jobs:
                     case JOB_STATUSES_ENUM.success:
                         jobs_statuses.success.push(file);
                         break;
-                    case JOB_STATUSES_ENUM.failed:
-                        jobs_statuses.failed.push(file);
+                    case JOB_STATUSES_ENUM.failure:
+                        jobs_statuses.failure.push(file);
                         break;
                     case JOB_STATUSES_ENUM.cancelled:
                         jobs_statuses.cancelled.push(file);
@@ -177,7 +177,7 @@ jobs:
                 }
             });
 
-            const jobs_statistics = `Jobs status: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}; ${JOB_STATUSES_ENUM.failed} - ${jobs_statuses.failed.length}; ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}; undefined: - ${jobs_statuses.undefined.length};`  
+            const jobs_statistics = `Jobs status: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}; ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}; ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}; undefined: - ${jobs_statuses.undefined.length};`  
             const slack_message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
 
             core.debug(slack_message+jobs_statistics);

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -63,10 +63,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - name: "Fail Job"
-        run: |
-          exit 1
-
       - name: "Set up Python - ${{ matrix.python-version }}"
         uses: actions/setup-python@v4
         with:
@@ -121,7 +117,7 @@ jobs:
   get-jobs-status:
     name: "Check Job Statuses"
     needs: [generate-artifact-name, pip-installation-test]
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
     with:
@@ -130,7 +126,7 @@ jobs:
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: get-jobs-status
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
@@ -138,4 +134,4 @@ jobs:
       notification_title: "pip nightly installation test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -177,7 +177,7 @@ jobs:
                 }
             });
 
-            const jobs_statistics = `Test jobs statuses - ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined status: - ${jobs_statuses.undefined.length}.`;  
+            const jobs_statistics = `Test jobs statuses: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined - ${jobs_statuses.undefined.length}.`;  
             const message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
             const slack_message = `${message} ${jobs_statistics}`;
             core.debug(slack_message);

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -75,7 +75,9 @@ jobs:
 
       - name: "Dump Job Status"
         run: |
-          toJson(job) > pip-installation/test-job-${{ strategy.job-index }}-${{ matrix.python-version }}.json
+          $JOB_CONTEXT > pip-installation/test-job-${{ strategy.job-index }}-${{ matrix.python-version }}.json
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
 
       - name: "Upload Job Status"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -119,7 +119,7 @@ jobs:
     needs: [generate-artifact-name, pip-installation-test]
     if: ${{ failure() && github.event_name == 'schedule' }}
 
-    uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+    uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:
       artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
 

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: "Dump Job Status"
         run: |
+          mkdir -p pip-installation
+          touch pip-installation/test-job-${{ strategy.job-index }}-${{ matrix.python-version }}.json
           $JOB_CONTEXT > pip-installation/test-job-${{ strategy.job-index }}-${{ matrix.python-version }}.json
         env:
           JOB_CONTEXT: ${{ toJson(job) }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -191,7 +191,7 @@ jobs:
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
       status: "failure"
-      notification_title: "needs.check-jobs-status.outputs.slack_message"
+      notification_title: ${{ needs.check-jobs-status.outputs.slack_message }}
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -120,74 +120,12 @@ jobs:
 
   check-jobs-status:
     name: "Check Job Statuses"
-    runs-on: ubuntu-latest
     needs: [generate-artifact-name, pip-installation-test]
     if: ${{ failure() }}
 
-    outputs:
-      slack_message: ${{ steps.get-slack-message.outputs.result }}
-
-    steps:
-      - name: "Download Artifact ${{ needs.generate-artifact-name.outputs.artifact-name }}"
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.version_number }}
-          path: .
-
-      - name: "[DEBUG] Display Structure Of All Downloaded Files"
-        run: ls -R
-
-      - name: "Generate Slack Message"
-        uses: actions/github-script@v6
-        id: get-slack-message
-        with:
-          result-encoding: string
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const artifact_folder = './${{ needs.generate-artifact-name.outputs.artifact-name }}'
-
-            const JOB_STATUSES_ENUM = {
-                success: "success",
-                failure: "failure",
-                cancelled: "cancelled"
-            };
-
-            const jobs_statuses = {
-                failure: [],
-                success: [],
-                cancelled: [],
-                undefined: []
-            };
-
-            const files_list = fs.readdirSync(artifact_folder);
-            core.debug(files_list);
-
-            files_list.map(file => {
-                const buffer = fs.readFileSync(`${artifact_folder}/${file}`);
-                const jobs_status = buffer.toString().trim().replace(/['"]+/g, '');
-
-                switch (jobs_status) {
-                    case JOB_STATUSES_ENUM.success:
-                        jobs_statuses.success.push(file);
-                        break;
-                    case JOB_STATUSES_ENUM.failure:
-                        jobs_statuses.failure.push(file);
-                        break;
-                    case JOB_STATUSES_ENUM.cancelled:
-                        jobs_statuses.cancelled.push(file);
-                        break;
-                    default:
-                        jobs_statuses.undefined.push(file);
-                }
-            });
-
-            const jobs_statistics = `Test jobs statuses: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined - ${jobs_statuses.undefined.length}.`;  
-            const message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
-            const slack_message = `${message} ${jobs_statistics}`;
-            core.debug(slack_message);
-
-            return slack_message;
+    uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+    with:
+      artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
 
   slack-notification:
     name: "Post Scheduled Run Failures"

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -73,6 +73,16 @@ jobs:
         run: |
           dbt --version
 
+      - name: "Dump Job Status"
+        run: |
+          toJson(job) > pip-installation/test-job-${{ strategy.job-index }}-${{ matrix.python-version }}.json
+
+      - name: "Upload Job Status"
+        uses: actions/upload-artifact@v3
+        with:
+          name: dbt-installation-logs
+          path: pip-installation/test-job-${{ strategy.job-index }}.txt
+
   dump-context:
     name: Dump Jobs Context
     runs-on: ubuntu-latest
@@ -91,7 +101,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-  
+
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: pip-installation-test
@@ -100,7 +110,7 @@ jobs:
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
       status: "failure"
-      notification_title: "pip nightly integration test failed for - ${{ inputs.package_name }}"
+      notification_title: "pip nightly installation test failed for - ${{ inputs.package_name }}"
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -63,6 +63,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
+      - name: "Fail Job"
+        run: exit 1
+      
       - name: "Set up Python - ${{ matrix.python-version }}"
         uses: actions/setup-python@v4
         with:
@@ -116,7 +119,8 @@ jobs:
 
   send-slack-notification:
     needs: [generate-artifact-name, pip-installation-test]
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    if: ${{ failure() }}
+    # if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -74,12 +74,15 @@ jobs:
           dbt --version
 
       - name: "Dump Job Status"
+        id: job-status
         run: |
           folder="pip-installation" 
           file="test-job-${{ strategy.job-index }}-python-version-v${{ matrix.python-version }}.json"
           mkdir -p $folder
           touch $folder/$file
           echo $JOB_CONTEXT >> $folder/$file
+          echo "path=$folder/$file" >> $GITHUB_OUTPUT
+
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
 
@@ -87,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: dbt-installation-logs
-          path: pip-installation/test-job-${{ strategy.job-index }}.txt
+          path: steps.job-status.outputs.path
 
   dump-context:
     name: Dump Jobs Context

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ always() }}
         id: job-status
         run: |
-          file="tets-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
+          file="test-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
           # Create file
           touch $file 
           # Write job status to file

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -114,24 +114,15 @@ jobs:
           path: ${{ steps.job-status.outputs.path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  get-jobs-status:
-    name: "Check Job Statuses"
+  send-slack-notification:
     needs: [generate-artifact-name, pip-installation-test]
     if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:
       artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
-
-  slack-notification:
-    name: "Post Scheduled Run Failures"
-    needs: get-jobs-status
-    if: ${{ failure() && github.event_name == 'schedule' }}
-
-    uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
-    with:
-      status: "failure"
-      notification_title: "pip nightly installation test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
+      installation_method: "pip"
+      package_name: ${{ inputs.package_name }}
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -177,12 +177,12 @@ jobs:
                 }
             });
 
-            const jobs_statistics = `Jobs status: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}; ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}; ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}; undefined: - ${jobs_statuses.undefined.length};`  
-            const slack_message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
+            const jobs_statistics = `Test jobs statuses - ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined status: - ${jobs_statuses.undefined.length}.`;  
+            const message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
+            const slack_message = `${message} ${jobs_statistics}`;
+            core.debug(slack_message);
 
-            core.debug(slack_message+jobs_statistics);
-
-            return slack_message+jobs_statistics;
+            return slack_message;
 
   slack-notification:
     name: "Post Scheduled Run Failures"

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -100,7 +100,7 @@ jobs:
           # Create file
           touch $file 
           # Write job status to file
-          echo $JOB_CONTEXT >> $file
+          echo $JOB_STATUS >> $file
           # Set path to file for subsequent steps          
           echo "path=$file" >> $GITHUB_OUTPUT
         env:
@@ -117,7 +117,7 @@ jobs:
     name: "Check Job Statuses"
     runs-on: ubuntu-latest
     needs: [generate-artifact-name, pip-installation-test]
-    if: ${{ failure()}}
+    # if: ${{ failure()}}
 
     outputs:
       slack_message: "pip nightly installation test failed for - ${{ inputs.package_name }}"

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: dbt-installation-logs
-          path: steps.job-status.outputs.path
+          path: ${{ steps.job-status.outputs.path }}
 
   dump-context:
     name: Dump Jobs Context

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -92,6 +92,10 @@ jobs:
         run: |
           dbt --version
 
+      - name: "Fail Job"
+        run: |
+          exit 1
+
       - name: "Dump Job Status"
         if: ${{ always() }}
         id: job-status
@@ -117,7 +121,7 @@ jobs:
     name: "Check Job Statuses"
     runs-on: ubuntu-latest
     needs: [generate-artifact-name, pip-installation-test]
-    # if: ${{ failure()}}
+    if: ${{ failure()}}
 
     outputs:
       slack_message: ${{ steps.get-slack-message.outputs.result }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -177,12 +177,12 @@ jobs:
                 }
             });
 
-            const jobs_statistics = `Jobs status: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}; ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}; ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}; undefined: - ${jobs_statuses.undefined.length};`  
+            const jobs_statistics = `Test jobs statuses - ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined: - ${jobs_statuses.undefined.length}.`;
             const slack_message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
+            const final_message = `${slack_message} ${jobs_statistics}`
+            core.debug(`${slack_message} ${jobs_statistics});
 
-            core.debug(slack_message+jobs_statistics);
-
-            return slack_message+jobs_statistics;
+            return final_message;
 
   slack-notification:
     name: "Post Scheduled Run Failures"

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           date=$(date +'%m%d%Y')
           name="${{ env.ARTIFACT_BASENAME }}-date"
-          echo "name=$name"" >> $GITHUB_OUTPUT
+          echo "name=$name" >> $GITHUB_OUTPUT
 
   pip-installation-test:
     runs-on: ubuntu-latest
@@ -135,7 +135,6 @@ jobs:
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: check-jobs-status
-    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -122,7 +122,7 @@ jobs:
     name: "Check Job Statuses"
     runs-on: ubuntu-latest
     needs: [generate-artifact-name, pip-installation-test]
-    if: ${{ failure()}}
+    if: ${{ failure() }}
 
     outputs:
       slack_message: ${{ steps.get-slack-message.outputs.result }}
@@ -192,6 +192,7 @@ jobs:
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: check-jobs-status
+    if: ${{ failure() }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -84,13 +84,14 @@ jobs:
           echo "path=$folder/$file" >> $GITHUB_OUTPUT
 
         env:
-          JOB_CONTEXT: ${{ toJson(job) }}
+          JOB_CONTEXT: ${{ toJson(job.status) }}
 
       - name: "Upload Job Status"
         uses: actions/upload-artifact@v3
         with:
           name: dbt-installation-logs
           path: ${{ steps.job-status.outputs.path }}
+          retention-days: 1
 
   dump-context:
     name: Dump Jobs Context

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           JOB_STATUS: ${{ toJson(job.status) }}
 
-      - name: "Upload Job Status"
+      - name: "Upload Job Status For Slack Notification"
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -135,7 +135,7 @@ jobs:
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
       status: "failure"
-      notification_title: "pip nightly installation test failed for - ${{ inputs.package_name }}.  ${{ needs.get-jobs-status.outputs.job_statistics }}"
+      notification_title: "pip nightly installation test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -75,9 +75,11 @@ jobs:
 
       - name: "Dump Job Status"
         run: |
-          mkdir -p pip-installation
-          touch pip-installation/test-job-${{ strategy.job-index }}-${{ matrix.python-version }}.json
-          $JOB_CONTEXT > pip-installation/test-job-${{ strategy.job-index }}-${{ matrix.python-version }}.json
+          folder="pip-installation" 
+          file="test-job-${{ strategy.job-index }}-python-version-v${{ matrix.python-version }}.json"
+          mkdir -p $folder
+          touch $folder/$file
+          echo $JOB_CONTEXT >> $folder/$file
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
 

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -140,7 +140,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const path_to_files = './${{ needs.generate-artifact-name.outputs.artifact-name }}'
+            const artifact_folder = './${{ needs.generate-artifact-name.outputs.artifact-name }}'
 
             const JOB_STATUSES_ENUM = {
                 success: "success",
@@ -155,10 +155,11 @@ jobs:
                 undefined: []
             };
 
-            const files_list = fs.readdirSync(path_to_files);
+            const files_list = fs.readdirSync(artifact_folder);
+            core.debug(files_list);
 
             files_list.map(file => {
-                const buffer = fs.readFileSync(file);
+                const buffer = fs.readFileSync(`${artifact_folder}/${file}`);
                 const jobs_status = buffer.toString().trim().replace(/['"]+/g, '');
 
                 switch (jobs_status) {

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -73,6 +73,25 @@ jobs:
         run: |
           dbt --version
 
+  dump-context:
+    name: Dump Jobs Context
+    runs-on: ubuntu-latest
+    needs: pip-installation-test
+
+    steps:
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump jobs context
+        env:
+          JOBS_CONTEXT: ${{ toJson(jobs) }}
+        run: echo "$JOBS_CONTEXT"
+  
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: pip-installation-test

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -63,6 +63,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
+      - name: "Fail Job"
+        run: |
+          exit 1
+
       - name: "Set up Python - ${{ matrix.python-version }}"
         uses: actions/setup-python@v4
         with:
@@ -92,10 +96,6 @@ jobs:
         run: |
           dbt --version
 
-      - name: "Fail Job"
-        run: |
-          exit 1
-
       - name: "Dump Job Status"
         if: ${{ always() }}
         id: job-status
@@ -111,6 +111,7 @@ jobs:
           JOB_STATUS: ${{ toJson(job.status) }}
 
       - name: "Upload Job Status"
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ needs.generate-artifact-name.outputs.artifact-name }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -118,7 +118,7 @@ jobs:
           path: ${{ steps.job-status.outputs.path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  check-jobs-status:
+  get-jobs-status:
     name: "Check Job Statuses"
     needs: [generate-artifact-name, pip-installation-test]
     if: ${{ failure() }}
@@ -129,13 +129,13 @@ jobs:
 
   slack-notification:
     name: "Post Scheduled Run Failures"
-    needs: check-jobs-status
+    needs: get-jobs-status
     if: ${{ failure() }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
       status: "failure"
-      notification_title: ${{ needs.check-jobs-status.outputs.slack_message }}
+      notification_title: "pip nightly installation test failed for - ${{ inputs.package_name }}.  ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -87,10 +87,6 @@ jobs:
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
         run: echo "$JOB_CONTEXT"
-      - name: Dump jobs context
-        env:
-          JOBS_CONTEXT: ${{ toJson(jobs) }}
-        run: echo "$JOBS_CONTEXT"
   
   slack-notification:
     name: "Post Scheduled Run Failures"

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -177,12 +177,12 @@ jobs:
                 }
             });
 
-            const jobs_statistics = `Test jobs statuses - ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined: - ${jobs_statuses.undefined.length}.`;
+            const jobs_statistics = `Jobs status: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}; ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}; ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}; undefined: - ${jobs_statuses.undefined.length};`  
             const slack_message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
-            const final_message = `${slack_message} ${jobs_statistics}`
-            core.debug(`${slack_message} ${jobs_statistics});
 
-            return final_message;
+            core.debug(slack_message+jobs_statistics);
+
+            return slack_message+jobs_statistics;
 
   slack-notification:
     name: "Post Scheduled Run Failures"

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -87,6 +87,10 @@ jobs:
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
         run: echo "$JOB_CONTEXT"
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   
   slack-notification:
     name: "Post Scheduled Run Failures"

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -63,9 +63,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - name: "Fail Job"
-        run: exit 1
-      
       - name: "Set up Python - ${{ matrix.python-version }}"
         uses: actions/setup-python@v4
         with:
@@ -119,8 +116,7 @@ jobs:
 
   send-slack-notification:
     needs: [generate-artifact-name, pip-installation-test]
-    if: ${{ failure() }}
-    # if: ${{ failure() && github.event_name == 'schedule' }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -50,7 +50,7 @@ jobs:
         id: artifact-name
         run: |
           date=$(date +'%m%d%Y')
-          name="${{ env.ARTIFACT_BASENAME }}-date"
+          name="${{ env.ARTIFACT_BASENAME }}-$date"
           echo "name=$name" >> $GITHUB_OUTPUT
 
   pip-installation-test:
@@ -120,7 +120,7 @@ jobs:
     # if: ${{ failure()}}
 
     outputs:
-      slack_message: "pip nightly installation test failed for - ${{ inputs.package_name }}"
+      slack_message: ${{ steps.get-slack-message.outputs.result }}
 
     steps:
       - name: "Download Artifact ${{ needs.generate-artifact-name.outputs.artifact-name }}"
@@ -132,6 +132,57 @@ jobs:
       - name: "[DEBUG] Display Structure Of All Downloaded Files"
         run: ls -R
 
+      - name: "Generate Slack Message"
+        uses: actions/github-script@v6
+        id: get-slack-message
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const path_to_files = './${{ needs.generate-artifact-name.outputs.artifact-name }}'
+
+            const JOB_STATUSES_ENUM = {
+                success: "success",
+                failure: "failure",
+                cancelled: "cancelled"
+            };
+
+            const jobs_statuses = {
+                failed: [],
+                success: [],
+                cancelled: [],
+                undefined: []
+            };
+
+            const files_list = fs.readdirSync(path_to_files);
+
+            files_list.map(file => {
+                const buffer = fs.readFileSync(file);
+                const jobs_status = buffer.toString().trim().replace(/['"]+/g, '');
+
+                switch (jobs_status) {
+                    case JOB_STATUSES_ENUM.success:
+                        jobs_statuses.success.push(file);
+                        break;
+                    case JOB_STATUSES_ENUM.failed:
+                        jobs_statuses.failed.push(file);
+                        break;
+                    case JOB_STATUSES_ENUM.cancelled:
+                        jobs_statuses.cancelled.push(file);
+                        break;
+                    default:
+                        jobs_statuses.undefined.push(file);
+                }
+            });
+
+            const jobs_statistics = `Jobs status: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}; ${JOB_STATUSES_ENUM.failed} - ${jobs_statuses.failed.length}; ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}; undefined: - ${jobs_statuses.undefined.length};`  
+            const slack_message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
+
+            core.debug(slack_message+jobs_statistics);
+
+            return slack_message+jobs_statistics;
+
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: check-jobs-status
@@ -142,4 +193,4 @@ jobs:
       notification_title: "needs.check-jobs-status.outputs.slack_message"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -34,9 +34,28 @@ on:
 permissions:
   contents: read # required for slack-post-notification workflow
 
+env:
+  ARTIFACT_BASENAME: "pip-installation-test"
+  ARTIFACT_RETENTION_DAYS: 1
+
 jobs:
+  generate-artifact-name:
+    runs-on: ubuntu-latest
+
+    outputs:
+      artifact-name: ${{ steps.artifact-name.outputs.name }}
+
+    steps:
+      - name: "Generate Artifact Name"
+        id: artifact-name
+        run: |
+          date=$(date +'%m%d%Y')
+          name="${{ env.ARTIFACT_BASENAME }}-date"
+          echo "name=$name"" >> $GITHUB_OUTPUT
+
   pip-installation-test:
     runs-on: ubuntu-latest
+    needs: generate-artifact-name
 
     strategy:
       fail-fast: false
@@ -74,53 +93,54 @@ jobs:
           dbt --version
 
       - name: "Dump Job Status"
+        if: ${{ always() }}
         id: job-status
         run: |
-          folder="pip-installation" 
-          file="test-job-${{ strategy.job-index }}-python-version-v${{ matrix.python-version }}.json"
-          mkdir -p $folder
-          touch $folder/$file
-          echo $JOB_CONTEXT >> $folder/$file
-          echo "path=$folder/$file" >> $GITHUB_OUTPUT
-
+          file="tets-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
+          # Create file
+          touch $file 
+          # Write job status to file
+          echo $JOB_CONTEXT >> $file
+          # Set path to file for subsequent steps          
+          echo "path=$file" >> $GITHUB_OUTPUT
         env:
-          JOB_CONTEXT: ${{ toJson(job.status) }}
+          JOB_STATUS: ${{ toJson(job.status) }}
 
       - name: "Upload Job Status"
         uses: actions/upload-artifact@v3
         with:
-          name: dbt-installation-logs
+          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
           path: ${{ steps.job-status.outputs.path }}
-          retention-days: 1
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  dump-context:
-    name: Dump Jobs Context
+  check-jobs-status:
+    name: "Check Job Statuses"
     runs-on: ubuntu-latest
-    needs: pip-installation-test
+    needs: [generate-artifact-name, pip-installation-test]
+    if: ${{ failure()}}
+
+    outputs:
+      slack_message: "pip nightly installation test failed for - ${{ inputs.package_name }}"
 
     steps:
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        run: echo "$MATRIX_CONTEXT"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        run: echo "$JOB_CONTEXT"
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+      - name: "Download Artifact ${{ needs.generate-artifact-name.outputs.artifact-name }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: .
+
+      - name: "[DEBUG] Display Structure Of All Downloaded Files"
+        run: ls -R
 
   slack-notification:
     name: "Post Scheduled Run Failures"
-    needs: pip-installation-test
+    needs: check-jobs-status
     if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
       status: "failure"
-      notification_title: "pip nightly installation test failed for - ${{ inputs.package_name }}"
+      notification_title: "needs.check-jobs-status.outputs.slack_message"
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -171,24 +171,15 @@ jobs:
           path: ${{ steps.job-status.outputs.path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  get-jobs-status:
-    name: "Check Job Statuses"
+  send-slack-notification:
     needs: [generate-artifact-name, source-installation-test]
     if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:
       artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
-
-  slack-notification:
-    name: "Post Scheduled Run Failures"
-    needs: get-jobs-status
-    if: ${{ failure() && github.event_name == 'schedule' }}
-
-    uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
-    with:
-      status: "failure"
-      notification_title: "Source nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
+      installation_method: "Source"
+      package_name: ${{ inputs.package_name }}
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -177,7 +177,7 @@ jobs:
 
   get-jobs-status:
     name: "Check Job Statuses"
-    needs: [generate-artifact-name, pip-installation-test]
+    needs: [generate-artifact-name, source-installation-test]
     if: ${{ failure() }}
 
     uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -163,7 +163,7 @@ jobs:
         env:
           JOB_STATUS: ${{ toJson(job.status) }}
 
-      - name: "Upload Job Status"
+      - name: "Upload Job Status For Slack Notification"
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -106,10 +106,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - name: "Fail Job"
-        run: |
-          exit 1
-
       - name: "Resolve Repository"
         id: repo-info
         run: |
@@ -178,7 +174,7 @@ jobs:
   get-jobs-status:
     name: "Check Job Statuses"
     needs: [generate-artifact-name, source-installation-test]
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
     with:
@@ -187,7 +183,7 @@ jobs:
   slack-notification:
     name: "Post Scheduled Run Failures"
     needs: get-jobs-status
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
@@ -195,4 +191,4 @@ jobs:
       notification_title: "Source nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -176,7 +176,7 @@ jobs:
     needs: [generate-artifact-name, source-installation-test]
     if: ${{ failure() && github.event_name == 'schedule' }}
 
-    uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+    uses: ./.github/workflows/test-dbt-installation-notify-job-statuses.yml
     with:
       artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
 

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -157,7 +157,7 @@ jobs:
         if: ${{ always() }}
         id: job-status
         run: |
-          file="tets-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
+          file="test-${{ strategy.job-index }}-branch-${{ matrix.branch }}-python-v${{ matrix.python-version }}.json"
           # Create file
           touch $file 
           # Write job status to file

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -36,8 +36,24 @@ permissions:
 
 env:
   NOTIFICATION_PREFIX: "[Source Installation Tests]"
+  ARTIFACT_BASENAME: "source-installation-test"
+  ARTIFACT_RETENTION_DAYS: 1
 
 jobs:
+  generate-artifact-name:
+    runs-on: ubuntu-latest
+
+    outputs:
+      artifact-name: ${{ steps.artifact-name.outputs.name }}
+
+    steps:
+      - name: "Generate Artifact Name"
+        id: artifact-name
+        run: |
+          date=$(date +'%m%d%Y')
+          name="${{ env.ARTIFACT_BASENAME }}-$date"
+          echo "name=$name" >> $GITHUB_OUTPUT
+
   fetch-latest-branches:
     runs-on: ubuntu-latest
 
@@ -81,7 +97,7 @@ jobs:
 
   source-installation-test:
     runs-on: ubuntu-latest
-    needs: fetch-latest-branches
+    needs: [fetch-latest-branches, generate-artifact-name]
 
     strategy:
       fail-fast: false
@@ -90,6 +106,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
+      - name: "Fail Job"
+        run: |
+          exit 1
+
       - name: "Resolve Repository"
         id: repo-info
         run: |
@@ -133,15 +153,46 @@ jobs:
         run: |
           dbt --version
 
+      - name: "Dump Job Status"
+        if: ${{ always() }}
+        id: job-status
+        run: |
+          file="tets-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
+          # Create file
+          touch $file 
+          # Write job status to file
+          echo $JOB_STATUS >> $file
+          # Set path to file for subsequent steps          
+          echo "path=$file" >> $GITHUB_OUTPUT
+        env:
+          JOB_STATUS: ${{ toJson(job.status) }}
+
+      - name: "Upload Job Status"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+          path: ${{ steps.job-status.outputs.path }}
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  get-jobs-status:
+    name: "Check Job Statuses"
+    needs: [generate-artifact-name, pip-installation-test]
+    if: ${{ failure() }}
+
+    uses: ./.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+    with:
+      artifact_name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+
   slack-notification:
     name: "Post Scheduled Run Failures"
-    needs: source-installation-test
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: get-jobs-status
+    if: ${{ failure() }}
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:
       status: "failure"
-      notification_title: "Source nightly integration test failed for - ${{ inputs.package_name }}"
+      notification_title: "Source nightly integration test failed for - ${{ inputs.package_name }}. ${{ needs.get-jobs-status.outputs.job_statistics }}"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}

--- a/.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+++ b/.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
@@ -9,7 +9,7 @@ name: dbt Installation - Verify Test Jobs Statuses
 on:
   workflow_call:
     inputs:
-      artifact-name:
+      artifact_name:
         required: true
         type: string
     outputs:
@@ -19,16 +19,14 @@ on:
 
 jobs:
   check-jobs-status:
-    name: "Check Job StatuAses"
+    name: "Check Job Statuses"
     runs-on: ubuntu-latest
-    needs: [generate-artifact-name, pip-installation-test]
-    if: ${{ failure() }}
 
     outputs:
       slack_message: ${{ steps.get-slack-message.outputs.result }}
 
     steps:
-      - name: "Download Artifact ${{ inputs.artifact-name }}"
+      - name: "Download Artifact ${{ inputs.artifact_name }}"
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.version_number }}
@@ -45,7 +43,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const artifact_folder = './${{ inputs.artifact-name }}'
+            const artifact_folder = './${{ inputs.artifact_name }}'
 
             const JOB_STATUSES_ENUM = {
                 success: "success",

--- a/.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+++ b/.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
@@ -1,0 +1,90 @@
+# **what?**
+
+# **why?**
+
+# **when?**
+
+name: dbt Installation - Verify Test Jobs Statuses
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        required: true
+        type: string
+    outputs:
+      slack_message:
+        description: "Message to post in Slack"
+        value: ${{ jobs.check-jobs-status.outputs.slack_message }}
+
+jobs:
+  check-jobs-status:
+    name: "Check Job StatuAses"
+    runs-on: ubuntu-latest
+    needs: [generate-artifact-name, pip-installation-test]
+    if: ${{ failure() }}
+
+    outputs:
+      slack_message: ${{ steps.get-slack-message.outputs.result }}
+
+    steps:
+      - name: "Download Artifact ${{ inputs.artifact-name }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: .
+
+      - name: "[DEBUG] Display Structure Of All Downloaded Files"
+        run: ls -R
+
+      - name: "Generate Slack Message"
+        uses: actions/github-script@v6
+        id: get-slack-message
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const artifact_folder = './${{ inputs.artifact-name }}'
+
+            const JOB_STATUSES_ENUM = {
+                success: "success",
+                failure: "failure",
+                cancelled: "cancelled"
+            };
+
+            const jobs_statuses = {
+                failure: [],
+                success: [],
+                cancelled: [],
+                undefined: []
+            };
+
+            const files_list = fs.readdirSync(artifact_folder);
+            core.debug(files_list);
+
+            files_list.map(file => {
+                const buffer = fs.readFileSync(`${artifact_folder}/${file}`);
+                const jobs_status = buffer.toString().trim().replace(/['"]+/g, '');
+
+                switch (jobs_status) {
+                    case JOB_STATUSES_ENUM.success:
+                        jobs_statuses.success.push(file);
+                        break;
+                    case JOB_STATUSES_ENUM.failure:
+                        jobs_statuses.failure.push(file);
+                        break;
+                    case JOB_STATUSES_ENUM.cancelled:
+                        jobs_statuses.cancelled.push(file);
+                        break;
+                    default:
+                        jobs_statuses.undefined.push(file);
+                }
+            });
+
+            const jobs_statistics = `Test jobs statuses: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined - ${jobs_statuses.undefined.length}.`;  
+            const message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
+            const slack_message = `${message} ${jobs_statistics}`;
+            core.debug(slack_message);
+
+            return slack_message;

--- a/.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
+++ b/.github/workflows/test-dbt-installation-verify-test-jobs-statuses.yml
@@ -13,9 +13,9 @@ on:
         required: true
         type: string
     outputs:
-      slack_message:
-        description: "Message to post in Slack"
-        value: ${{ jobs.check-jobs-status.outputs.slack_message }}
+      job_statistics:
+        description: "Overall statistics regarding jobs statuses"
+        value: ${{ jobs.check-jobs-status.outputs.job_statistics }}
 
 jobs:
   check-jobs-status:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      slack_message: ${{ steps.get-slack-message.outputs.result }}
+      job_statistics: ${{ steps.get-job_statistics.outputs.result }}
 
     steps:
       - name: "Download Artifact ${{ inputs.artifact_name }}"
@@ -37,7 +37,7 @@ jobs:
 
       - name: "Generate Slack Message"
         uses: actions/github-script@v6
-        id: get-slack-message
+        id: get-job_statistics
         with:
           result-encoding: string
           script: |
@@ -80,9 +80,7 @@ jobs:
                 }
             });
 
-            const jobs_statistics = `Test jobs statuses: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined - ${jobs_statuses.undefined.length}.`;  
-            const message = "pip nightly installation test failed for - ${{ inputs.package_name }}.";
-            const slack_message = `${message} ${jobs_statistics}`;
-            core.debug(slack_message);
+            const job_statistics = `Test jobs statuses: ${JOB_STATUSES_ENUM.success} - ${jobs_statuses.success.length}, ${JOB_STATUSES_ENUM.failure} - ${jobs_statuses.failure.length}, ${JOB_STATUSES_ENUM.cancelled} - ${jobs_statuses.cancelled.length}, undefined - ${jobs_statuses.undefined.length}.`;
+            core.debug(job_statistics);
 
-            return slack_message;
+            return job_statistics;


### PR DESCRIPTION
**Description**:
This pull request contains the implementation for the Slack notifications about failed dbt installation tests.

All workflows were adjusted to dump job statuses. These dumps are uploaded as build artifacts. Additionally, a new workflow was introduced. The main idea of this workflow is to process job statuses and generate reports. In the current implementation, the workflow downloads the artifact processes job statuses and provides statistics in the following format:
```console
Test jobs statuses: success - 0, failure - 5, cancelled - 0, undefined - 0.
```

**Changelog**:
test-dbt-installation-verify-test-jobs-statuses.yml:
- Added initial implementation;

test-dbt-installation-main.yml:
- Enabled schedule trigger;

test-dbt-installation-docker.yml:
- Added step to dump job status;
- Added steps to generate artifact name and upload artifact;
- Added step to generate statistics regarding jobs;

test-dbt-installation-homebrew.yml:
- Main job was renamed;
- Added step to dump job status;
- Added steps to generate artifact name and upload artifact;
- Added step to generate statistics regarding jobs;

test-dbt-installation-pip.yml:
- Added step to dump job status;
- Added steps to generate artifact name and upload artifact;
- Added step to generate statistics regarding jobs;

test-dbt-installation-sources.yml:
- Added step to dump job status;
- Added steps to generate artifact name and upload artifact;
- Added step to generate statistics regarding jobs;

**Run examples**:
- https://github.com/dbt-labs/actions/actions/runs/3996783736
- https://github.com/dbt-labs/actions/actions/runs/3996737859
- https://github.com/dbt-labs/actions/actions/runs/3996594066