### PR TITLE
[dbt installation] Change name pattern for job dump and replace Slack secret

### DIFF
--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -139,7 +139,7 @@ jobs:
         if: ${{ always() }}
         id: job-status
         run: |
-          file="test-${{ strategy.job-index }}-tag-${{ matrix.tag }}.json"
+          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-tag-${{ matrix.tag }}.json"
           # Create file
           touch $file 
           # Write job status to file

--- a/.github/workflows/test-dbt-installation-main.yml
+++ b/.github/workflows/test-dbt-installation-main.yml
@@ -50,7 +50,7 @@ jobs:
     with:
       package_name: ${{ matrix.package }}
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
 
   dbt-installation-pip:
     if: >-
@@ -73,7 +73,7 @@ jobs:
     with:
       package_name: ${{ matrix.package }}
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
 
   dbt-installation-docker:
     if: >-
@@ -96,7 +96,7 @@ jobs:
     with:
       package_name: ${{ matrix.package }}
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
 
   dbt-installation-source:
     if: >-
@@ -119,4 +119,4 @@ jobs:
     with:
       package_name: ${{ matrix.package }}
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}

--- a/.github/workflows/test-dbt-installation-notify-job-statuses.yml
+++ b/.github/workflows/test-dbt-installation-notify-job-statuses.yml
@@ -77,21 +77,23 @@ jobs:
             core.debug(files_list);
 
             files_list.map(file => {
-                const buffer = fs.readFileSync(`${artifact_folder}/${file}`);
-                const jobs_status = buffer.toString().trim().replace(/['"]+/g, '');
+                if (file.includes(${{ inputs.package_name }})) {
+                  const buffer = fs.readFileSync(`${artifact_folder}/${file}`);
+                  const jobs_status = buffer.toString().trim().replace(/['"]+/g, '');
 
-                switch (jobs_status) {
-                    case JOB_STATUSES_ENUM.success:
-                        jobs_statuses.success.push(file);
-                        break;
-                    case JOB_STATUSES_ENUM.failure:
-                        jobs_statuses.failure.push(file);
-                        break;
-                    case JOB_STATUSES_ENUM.cancelled:
-                        jobs_statuses.cancelled.push(file);
-                        break;
-                    default:
-                        jobs_statuses.undefined.push(file);
+                  switch (jobs_status) {
+                      case JOB_STATUSES_ENUM.success:
+                          jobs_statuses.success.push(file);
+                          break;
+                      case JOB_STATUSES_ENUM.failure:
+                          jobs_statuses.failure.push(file);
+                          break;
+                      case JOB_STATUSES_ENUM.cancelled:
+                          jobs_statuses.cancelled.push(file);
+                          break;
+                      default:
+                          jobs_statuses.undefined.push(file);
+                  }
                 }
             });
 

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -96,7 +96,7 @@ jobs:
         if: ${{ always() }}
         id: job-status
         run: |
-          file="test-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
+          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
           # Create file
           touch $file 
           # Write job status to file

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -153,7 +153,7 @@ jobs:
         if: ${{ always() }}
         id: job-status
         run: |
-          file="test-${{ strategy.job-index }}-branch-${{ matrix.branch }}-python-v${{ matrix.python-version }}.json"
+          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-branch-${{ matrix.branch }}-python-v${{ matrix.python-version }}.json"
           # Create file
           touch $file 
           # Write job status to file


### PR DESCRIPTION
**Description**:
During workflow runtime, we collect jobs dump to use them for notifications. The current name pattern for file names causes the files to overwrite due to name collisions. This PR changes the pattern for file names to avoid it.

**Changelog**:
- Name pattern now includes package name to avoid files overwrite;
- Changed secret for Slack;

**Run example**:
- https://github.com/dbt-labs/actions/actions/runs/4023512896