### PR TITLE
include another label

### DIFF
--- a/scripts/core-triage/project.py
+++ b/scripts/core-triage/project.py
@@ -33,6 +33,7 @@ ISSUE_LABELS = [
     "Team:Language",
     "Team:Execution",
     "Team:Adapters",
+    "internal_tooling",
 ]
 # prs added by label individually TODO: unused, add label filtering
 PR_LABELS = ["ready_for_review"]


### PR DESCRIPTION
Add a new label to support tracking issues for internal_tooling across repos that are currently less tracked.