### PR TITLE
update used gh actions ahead of set-output, node12 deprecation

### DIFF
--- a/.github/workflows/changelog-existence.yml
+++ b/.github/workflows/changelog-existence.yml
@@ -71,7 +71,7 @@ jobs:
       # this step uses the read permission from the GITHUB_TOKEN it inherits
       - name: Check for comment
         if: steps.changelog_check.outputs.exists == 'false'
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v2
         id: changelog_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -96,7 +96,7 @@ jobs:
         if: |
           steps.changelog_check.outputs.exists == 'false' &&
           steps.comment_check.outputs.exists == 'false'
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ inputs.changelog_comment }}

--- a/.github/workflows/core-triage.yml
+++ b/.github/workflows/core-triage.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/jira-creation.yml
+++ b/.github/workflows/jira-creation.yml
@@ -37,13 +37,13 @@ jobs:
   create-issue:
     runs-on: ubuntu-latest
     if: |
-      ((github.event.action == 'opened') || 
+      ((github.event.action == 'opened') ||
       (github.event.action == 'labeled' && github.event.label.name == 'jira'))
     outputs:
       issueId: ${{ steps.save-id.outputs.issueId }}
     steps:
       - name: Login
-        uses: atlassian/gajira-login@v2.0.0
+        uses: atlassian/gajira-login@v3
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create JIRA Ticket
         id: create
-        uses: atlassian/gajira-create@v2.0.1
+        uses: atlassian/gajira-create@v3
         with:
           project: ${{ inputs.project_key }}
           issuetype: "GitHub Issue"
@@ -112,10 +112,10 @@ jobs:
           echo "Issue ID:            ${{ needs.create-issue.outputs.issueId }}"
 
       - name: Setup Jira
-        uses: atlassian/gajira-cli@v2.0.2
+        uses: atlassian/gajira-cli@v3
 
       - name: Login
-        uses: atlassian/gajira-login@v2.0.0
+        uses: atlassian/gajira-login@v3
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -64,10 +64,10 @@ jobs:
           echo "Issue ID:            ${{ needs.extract-id.outputs.issueId }}"
 
       - name: Setup Jira
-        uses: atlassian/gajira-cli@v2.0.2
+        uses: atlassian/gajira-cli@v3
 
       - name: Login
-        uses: atlassian/gajira-login@v2.0.0
+        uses: atlassian/gajira-login@v3
 
       - name: Add label
         if: github.event.action == 'labeled'

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -56,7 +56,7 @@ jobs:
           echo "Issue ID:            ${{ needs.extract-id.outputs.issueId }}"
 
       - name: Jira login
-        uses: atlassian/gajira-login@v2.0.0
+        uses: atlassian/gajira-login@v3
         env:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
@@ -64,14 +64,14 @@ jobs:
 
       - name: Transition issue in Jira to Done
         if: github.event.action == 'closed' || github.event.action == 'deleted'
-        uses: atlassian/gajira-transition@v2.0.2
+        uses: atlassian/gajira-transition@v3
         with:
           issue: "${{ needs.extract-id.outputs.issueId }}"
           transition: "Done"
 
       - name: Transition issue in Jira to To Do
         if: github.event.action == 'reopened'
-        uses: atlassian/gajira-transition@v2.0.2
+        uses: atlassian/gajira-transition@v3
         with:
           issue: "${{ needs.extract-id.outputs.issueId }}"
           transition: "Backlog"

--- a/.github/workflows/parse-semver.yml
+++ b/.github/workflows/parse-semver.yml
@@ -12,7 +12,7 @@ jobs:
   test-valid:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Parse Semver
         id: parse-valid
@@ -36,7 +36,7 @@ jobs:
   test-invalid:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Parse Semver
         id: parse-invalid

--- a/.github/workflows/py-package-info.yml
+++ b/.github/workflows/py-package-info.yml
@@ -12,7 +12,7 @@ jobs:
   test-with-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Python Package Info
         id: with-version
@@ -33,7 +33,7 @@ jobs:
   test-without-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Python Package Info
         id: without-version
@@ -52,7 +52,7 @@ jobs:
   test-invalid:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Python Package Info
         id: invalid-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # Bump version on merging Pull Requests with specific labels.
@@ -32,7 +32,7 @@ jobs:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: haya14busa/action-bumpr@v1

--- a/.github/workflows/stale-bot-matrix.yml
+++ b/.github/workflows/stale-bot-matrix.yml
@@ -35,7 +35,7 @@ jobs:
   stale-awaiting-response:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         with:
           stale-issue-message: ${{ env.STALE_ISSUE_MSG }}
           stale-pr-message: ${{ env.STALE_PR_MSG }}
@@ -48,7 +48,7 @@ jobs:
   stale-first-issue:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         with:
           stale-issue-message: ${{ env.STALE_ISSUE_MSG }}
           stale-pr-message: ${{ env.STALE_PR_MSG }}
@@ -61,7 +61,7 @@ jobs:
   stale-tech-debt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         with:
           stale-issue-message: ${{ env.STALE_ISSUE_MSG }}
           stale-pr-message: ${{ env.STALE_PR_MSG }}
@@ -74,7 +74,7 @@ jobs:
   stale-default:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         with:
           stale-issue-message: ${{ env.STALE_ISSUE_MSG }}
           stale-pr-message: ${{ env.STALE_PR_MSG }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -98,10 +98,10 @@ jobs:
         run: |
           file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
           # Create file
-          touch $file 
+          touch $file
           # Write job status to file
           echo $JOB_STATUS >> $file
-          # Set path to file for subsequent steps          
+          # Set path to file for subsequent steps
           echo "path=$file" >> $GITHUB_OUTPUT
         env:
           JOB_STATUS: ${{ toJson(job.status) }}

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -144,10 +144,10 @@ jobs:
         run: |
           file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-branch-${{ matrix.branch }}-python-v${{ matrix.python-version }}.json"
           # Create file
-          touch $file 
+          touch $file
           # Write job status to file
           echo $JOB_STATUS >> $file
-          # Set path to file for subsequent steps          
+          # Set path to file for subsequent steps
           echo "path=$file" >> $GITHUB_OUTPUT
         env:
           JOB_STATUS: ${{ toJson(job.status) }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -109,7 +109,7 @@ jobs:
       - name: "Delete the json File"
         run: |
           rm ${{ steps.json_file.outputs.name }}
-      
+
       - name: "Run changie"
         run: |
           if [[ ${{ steps.semver.outputs.is-pre-release }} -eq 1 ]]
@@ -139,7 +139,7 @@ jobs:
           git status
 
       - name: "Commit & Create Pull Request"
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           author: "Github Build Bot <buildbot@fishtownanalytics.com>"
           base: ${{github.ref}}

--- a/fetch-container-tags/README.md
+++ b/fetch-container-tags/README.md
@@ -10,13 +10,13 @@ on: push
 jobs:
   fetch-latest-tags:
     runs-on: ubuntu-latest
-    
+
     outputs:
       latest-tags: ${{ steps.fetch-latest-tags.outputs.container-tags }}
-    
+
     steps:
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v3
+
       - name: "Fetch dbt-postgres Container Tags"
         id: get-latest-tags
         uses: dbt-labs/actions/fetch-container-tags
@@ -31,7 +31,7 @@ jobs:
       - name: "Display Container Tags"
         run: |
           echo container latest tags: ${{ steps.fetch-latest-tags.outputs.container-tags }}
-    
+
   dynamic-matrix:
     runs-on: ubuntu-latest
     needs: fetch-latest-tags
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         tag: ${{ fromJSON(needs.fetch-latest-tags.outputs.latest-tags) }}
-    
+
     steps:
       - name: "Display Tag Name"
         run: |

--- a/fetch-repo-branches/README.md
+++ b/fetch-repo-branches/README.md
@@ -10,13 +10,13 @@ on: push
 jobs:
   fetch-latest-branches:
     runs-on: ubuntu-latest
-    
+
     outputs:
       latest-branches: ${{ steps.get-latest-branches.outputs.repo-branches }}
-    
+
     steps:
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v3
+
       - name: "Fetch ${{ inputs.package_name }} Protected Branches Metadata"
         uses: dbt-labs/actions/fetch-repo-branches
         id: get-latest-branches
@@ -32,7 +32,7 @@ jobs:
       - name: "Display Latest Branches"
         run: |
           echo repo latest branches: ${{ steps.get-latest-branches.outputs.repo-branches }}
-      
+
     dynamic-matrix:
       runs-on: ubuntu-latest
       needs: fetch-latest-branches
@@ -41,7 +41,7 @@ jobs:
         fail-fast: false
         matrix:
           branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
-      
+
       steps:
         - name: "Display Branch Name"
           run: |

--- a/parse-semver/README.md
+++ b/parse-semver/README.md
@@ -11,7 +11,7 @@ jobs:
   parse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Parse Semver
         id: parse-valid
         uses: dbt-labs/actions/parse-semver

--- a/py-package-info/README.md
+++ b/py-package-info/README.md
@@ -11,7 +11,7 @@ jobs:
   parse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Package Info
         id: package-info
         uses: dbt-labs/actions/py-package-info


### PR DESCRIPTION
Update versions of used Github Actions ahead of:
- [node12 deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) (Summer 2023)
- [set-output deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) fully disabled on 31st May 2023)