### PR TITLE
fix missing trigger on workflows

### DIFF
--- a/.github/workflows/jira-creation-actions.yml
+++ b/.github/workflows/jira-creation-actions.yml
@@ -13,6 +13,7 @@ name: Jira Issue Creation
 on:
   issues:
     types: [opened, labeled]
+  workflow_call:
 
 permissions:
   issues: write

--- a/.github/workflows/jira-label-actions.yml
+++ b/.github/workflows/jira-label-actions.yml
@@ -13,6 +13,7 @@ name: Jira Label Mirroring
 on:
   issues:
     types: [labeled, unlabeled]
+  workflow_call:
 
 permissions:
   issues: read

--- a/.github/workflows/jira-transition-actions.yml
+++ b/.github/workflows/jira-transition-actions.yml
@@ -14,6 +14,7 @@ name: Jira Issue Transition
 on:
   issues:
     types: [closed, deleted, reopened]
+  workflow_call:
 
 # no special access is needed
 permissions: read-all

--- a/.github/workflows/swap-labels.yml
+++ b/.github/workflows/swap-labels.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: "Add triage label"
+      - name: "Add ${{ inputs.add_label }} label"
         uses: actions/github-script@v6
         with:
           script: |
@@ -49,7 +49,7 @@ jobs:
               labels: ["${{ inputs.add_label }}"]
             })
 
-      - name: "Remove awaiting_response label"
+      - name: "Remove ${{ inputs.remove_label }} label"
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
jira workflows need a workflow_call trigger.  Everything that uses teh CT tag uses these workflows.