### PR TITLE
centralize release branch tests

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -58,7 +58,8 @@ jobs:
         run: |
           echo ${{ steps.get-latest-branches.outputs.repo-branches }}
           full_branch_list=($(echo "${{ fromJSON(steps.get-latest-branches.outputs.repo-branches) }}" | jq -r '.[]'))
-          full_branch_list+="main"
+          echo $full_branch_list
+          full_branch_list+=("main")
           echo $full_branch_list
           echo "full_branch_list=$full_branch_list" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -74,7 +74,7 @@ jobs:
         branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
         include:
           - branch: 'main'
-        workflow_name: ["main.yml"]
+        workflow_name: ${{ fromJson(${{ inputs.workflows_to_run }}) }}
 
     steps:
       - name: Check out ${{ matrix.branch }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -74,7 +74,7 @@ jobs:
         branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
         include:
           - branch: 'main'
-        workflow_name: ${{ fromJson(${{ inputs.workflows_to_run }}) }}
+        workflow_name: ${{ fromJson(inputs.workflows_to_run) }}
 
     steps:
       - name: Check out ${{ matrix.branch }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -125,8 +125,7 @@ jobs:
       - name: Wait for run to complete
         id: monitor-run
         run: |
-          # gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
-          exit 1
+          gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -146,8 +145,7 @@ jobs:
         if: ${{ always() && steps.monitor-run.outcome != 'success' }}
         with:
           status: ${{ job.status }}
-          # notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
-          notification_title: 'This is Emily testing - ignore it'
+          notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
           message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
           footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
         env:

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -59,7 +59,7 @@ jobs:
           full_branch_list="${{ steps.get-latest-branches.outputs.repo-branches }}"
           # Swap single and double quotes because bash doesnt interpret correctly
           full_branch_list="${full_branch_list//\'/__SINGLE_QUOTE__}"
-          full_branch_list="${full_branch_list//\"/'}"
+          full_branch_list="${full_branch_list//\"/\'}"
           full_branch_list="${full_branch_list//__SINGLE_QUOTE__/\"}"
           echo $full_branch_list
           full_branch_list=($(echo "$full_branch_list" | jq -r '.[]'))

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Wait for run to complete
         id: monitor-run
         run: |
-          gh run watch ${{ steps.workflow-id.outputs.id }} --exit-status
+          gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
         env:
           GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
 

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -59,7 +59,9 @@ jobs:
           full_branch_list="${{ steps.get-latest-branches.outputs.repo-branches }}"
           # Swap single and double quotes because bash doesnt interpret correctly
           full_branch_list="${full_branch_list//\'/__SINGLE_QUOTE__}"
+          echo $full_branch_list
           full_branch_list="${full_branch_list//\"/\'}"
+          echo $full_branch_list
           full_branch_list="${full_branch_list//__SINGLE_QUOTE__/\"}"
           echo $full_branch_list
           # now convert it to a bash array and add the main branch

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -57,7 +57,10 @@ jobs:
         id: add-main
         run: |
           echo ${{ steps.get-latest-branches.outputs.repo-branches }}
-          full_branch_list=($(echo "${{ fromJSON(steps.get-latest-branches.outputs.repo-branches) }}" | jq -r '.[]'))
+          # Swap single and double quotes using jq because bash doesnt interpret correctly
+          full_branch_list=$(jq -R 'gsub("\'\''"; "__SINGLE_QUOTE__") | gsub("\""; "'\''") | gsub("__SINGLE_QUOTE__"; "\"")' <<< "${{ steps.get-latest-branches.outputs.repo-branches }}")
+          echo $full_branch_list
+          full_branch_list=($(echo "$full_branch_list" | jq -r '.[]'))
           echo $full_branch_list
           full_branch_list+=("main")
           echo $full_branch_list

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           gh workflow run ${{ matrix.workflow_name }} --ref ${{ matrix.branch }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
 
       - name: Get workflow run ID
         id: workflow-id

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -26,7 +26,7 @@ on:
 permissions: read-all
 
 jobs:
-  prep_work:
+  prep-work:
     name: "Audit Inputs"
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +35,6 @@ jobs:
           echo "workflows_to_run:    ${{ inputs.workflows_to_run }}"
 
   fetch-latest-branches:
-    needs: [prep-work]
     runs-on: ubuntu-latest
 
     outputs:

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           gh workflow run ${{ matrix.workflow_name }} --ref ${{ matrix.branch }}
         env:
-          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get workflow run ID
         id: workflow-id
@@ -98,14 +98,14 @@ jobs:
            echo $id
            echo "id=$id" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for run to complete
         id: monitor-run
         run: |
           gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
         env:
-          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # - name: Post failure to Slack
     #   uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -57,7 +57,7 @@ jobs:
         id: add-main
         run: |
           full_branch_list=(${{ steps.get-latest-branches.outputs.repo-branches }} "main")
-          echo "full_branch_list=full_branch_list" >> $GITHUB_OUTPUT
+          echo "full_branch_list=$full_branch_list" >> $GITHUB_OUTPUT
 
       - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"
         run: |

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -137,7 +137,7 @@ jobs:
           url=$(gh run view ${{ steps.workflow-id.outputs.id }} --json url -q ".url")
           echo "workflow-url=$url" >> $GITHUB_OUTPUT
           conclusion=$(gh run view ${{ steps.workflow-id.outputs.id }} --json conclusion -q ".conclusion")
-          echo "workflow-conclusion=$uconclusionrl" >> $GITHUB_OUTPUT
+          echo "workflow-conclusion=$conclusion" >> $GITHUB_OUTPUT
 
       - name: Post failure to Slack
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -65,7 +65,7 @@ jobs:
           full_branch_list="${full_branch_list//__SINGLE_QUOTE__/\"}"
           echo $full_branch_list
           # now convert it to a bash array and add the main branch
-          IFS=$'\n' read -d '' -r -a array <<< $(echo "$full_branch_list" | jq -r '.[]')
+          full_branch_list=($(echo "$full_branch_list" | jq -r '.[]'))
           for item in "${full_branch_list[@]}"; do   echo "$item"; done
           full_branch_list+=("main")
           for item in "${full_branch_list[@]}"; do   echo "$item"; done

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -1,6 +1,6 @@
 # **what?**
 # The purpose of this workflow is to trigger CI to run for each
-# release branch and main branch on a regular cadence. If the CI workflow
+# release branch and main branch in a reusable format. If the CI workflow
 # fails for a branch, it will post to dev-core-alerts to raise awareness.
 
 # **why?**
@@ -26,7 +26,16 @@ on:
 permissions: read-all
 
 jobs:
+  prep_work:
+    name: "Audit Inputs"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[DEBUG] Print Inputs"
+        run: |
+          echo "workflows_to_run:    ${{ inputs.workflows_to_run }}"
+
   fetch-latest-branches:
+    needs: [prep-work]
     runs-on: ubuntu-latest
 
     outputs:

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -41,7 +41,7 @@ jobs:
       latest-branches: ${{ steps.get-latest-branches.outputs.repo-branches }}
 
     steps:
-      - name: "Fetch dbt-core Latest Branches"
+      - name: "Fetch ${{ github.event.repository.name }} Latest Branches"
         uses: dbt-labs/actions/fetch-repo-branches@v1.1.1
         id: get-latest-branches
         with:
@@ -71,48 +71,54 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
+        workflow_name: ${{ fromJson(inputs.workflows_to_run) }}
         branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
         include:
           - branch: 'main'
-        workflow_name: ${{ fromJson(inputs.workflows_to_run) }}
+          - workflow_name: ${{ fromJson(inputs.workflows_to_run) }}
 
     steps:
-      - name: Check out ${{ matrix.branch }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.branch }}
-
-      - name: Call CI workflow for ${{ matrix.branch }} branch
-        id: trigger-step
+      - name: "[DEBUG] Print Inputs"
         run: |
-          gh workflow run ${{ matrix.workflow_name }} --ref ${{ matrix.branch }}
-        env:
-          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+          echo "matrix.branch:           ${{ matrix.branch }}"
+          echo "matrix.workflow_name:    ${{ matrix.workflow_name }}"
 
-      - name: Get workflow run ID
-        id: workflow-id
-        run: |
-           table=$(gh run list --workflow=${{ matrix.workflow_name }})
-           echo $table
-           id=$(echo "$table" | awk 'NR==1' | jq -Rr 'split("\t")[6]')
-           echo $id
-           echo "id=$id" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Check out ${{ matrix.branch }}
+      #   uses: actions/checkout@v3
+      #   with:
+      #     ref: ${{ matrix.branch }}
 
-      - name: Wait for run to complete
-        id: monitor-run
-        run: |
-          gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Call CI workflow for ${{ matrix.branch }} branch
+      #   id: trigger-step
+      #   run: |
+      #     gh workflow run ${{ matrix.workflow_name }} --ref ${{ matrix.branch }}
+      #   env:
+      #     GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      # - name: Get workflow run ID
+      #   id: workflow-id
+      #   run: |
+      #      table=$(gh run list --workflow=${{ matrix.workflow_name }})
+      #      echo $table
+      #      id=$(echo "$table" | awk 'NR==1' | jq -Rr 'split("\t")[6]')
+      #      echo $id
+      #      echo "id=$id" >> $GITHUB_OUTPUT
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Wait for run to complete
+      #   id: monitor-run
+      #   run: |
+      #     gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # - name: Post failure to Slack
     #   uses: ravsamhq/notify-slack-action@v2
     #   if: ${{ always() && !contains(steps.trigger-step.outputs.workflow-conclusion,'success') }}
     #   with:
     #     status: ${{ job.status }}
-    #     notification_title: 'dbt-core scheduled run of "${{ matrix.branch }}" branch not successful'
+    #     notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
     #     message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.trigger-step.outputs.workflow-conclusion }}'
     #     footer: 'Linked failed CI run ${{ steps.trigger-step.outputs.workflow-url }}'
     #   env:

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -104,6 +104,10 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      # We have to use a workflow_dispatch here because we're using the matrix branch value.
+      # Calling a workflow using the `uses` syntax does not give us access to any context so
+      # we must use hardcoded tags/branches/SHAs.  This also means we need to manually monitor
+      # for when the workflow completes.
       - name: Call CI workflow for ${{ matrix.branch }} branch
         id: trigger-step
         run: |

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: "Add main to branch list"
         id: add-main
         run: |
-          full_branch_list=${{ steps.get-latest-branches.outputs.repo-branches }}
+          full_branch_list="${{ steps.get-latest-branches.outputs.repo-branches }}"
           # Swap single and double quotes because bash doesnt interpret correctly
           full_branch_list="${full_branch_list//\'/__SINGLE_QUOTE__}"
           full_branch_list="${full_branch_list//\"/'}"

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -138,6 +138,8 @@ jobs:
           echo "workflow-url=$url" >> $GITHUB_OUTPUT
           conclusion=$(gh run view ${{ steps.workflow-id.outputs.id }} --json conclusion -q ".conclusion")
           echo "workflow-conclusion=$conclusion" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post failure to Slack
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -66,6 +66,7 @@ jobs:
           echo $full_branch_list
           # now convert it to a bash array and add the main branch
           IFS=$'\n' read -d '' -r -a full_branch_list <<< "$(jq -r '.[]' <<< $full_branch_list)"
+          echo "after it"
           for item in "${full_branch_list[@]}"; do   echo "$item"; done
           full_branch_list+=("main")
           for item in "${full_branch_list[@]}"; do   echo "$item"; done

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -65,8 +65,7 @@ jobs:
           full_branch_list="${full_branch_list//__SINGLE_QUOTE__/\"}"
           echo $full_branch_list
           # now convert it to a bash array and add the main branch
-          IFS=$'\n' read -d '' -r -a full_branch_list <<< "$(jq -r '.[]' <<< $full_branch_list)"
-          echo "after it"
+          IFS=$'\n' read -d '' -r -a array <<< $(echo "$full_branch_list" | jq -r '.[]')
           for item in "${full_branch_list[@]}"; do   echo "$item"; done
           full_branch_list+=("main")
           for item in "${full_branch_list[@]}"; do   echo "$item"; done

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -124,18 +124,28 @@ jobs:
 
       - name: Wait for run to complete
         id: monitor-run
+        continue-on-error: true
         run: |
           gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get slack message details for failed runs
+        if: ${{ steps.monitor-run.outcome != 'success' }}
+        id: status-check
+        run: |
+          url=$(gh run view ${{ steps.workflow-id.outputs.id }} --json url -q ".url")
+          echo "workflow-url=$url" >> $GITHUB_OUTPUT
+          conclusion=$(gh run view ${{ steps.workflow-id.outputs.id }} --json conclusion -q ".conclusion")
+          echo "workflow-conclusion=$uconclusionrl" >> $GITHUB_OUTPUT
+
       - name: Post failure to Slack
         uses: ravsamhq/notify-slack-action@v2
-        if: ${{ always() && !contains(steps.trigger-step.outputs.workflow-conclusion,'success') }}
+        if: ${{ steps.monitor-run.outcome != 'success' }}
         with:
           status: ${{ job.status }}
           notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
-          message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.trigger-step.outputs.workflow-conclusion }}'
-          footer: 'Linked failed CI run ${{ steps.trigger-step.outputs.workflow-url }}'
+          message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
+          footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -57,7 +57,9 @@ jobs:
         id: add-main
         run: |
           echo ${{ steps.get-latest-branches.outputs.repo-branches }}
-          full_branch_list=("${{ steps.get-latest-branches.outputs.repo-branches }}" "main")
+          full_branch_list=${{ fromJSON(steps.get-latest-branches.outputs.repo-branches) }}
+          full_branch_list+="main"
+          echo $full_branch_list
           echo "full_branch_list=$full_branch_list" >> $GITHUB_OUTPUT
 
       - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         workflow_name: ${{ fromJson(inputs.workflows_to_run) }}
-        branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.branches_to_test) }}
+        branch: ['1.5.latest']
 
     steps:
       - name: "[DEBUG] Print Inputs"
@@ -127,6 +127,7 @@ jobs:
         continue-on-error: true
         run: |
           gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
+          exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -144,7 +145,8 @@ jobs:
         if: ${{ steps.monitor-run.outcome != 'success' }}
         with:
           status: ${{ job.status }}
-          notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
+          # notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
+          notification_title: 'This is Emily testing - ignore it'
           message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
           footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
         env:

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -18,7 +18,7 @@ on:
   workflow_call:
     inputs:
       workflows_to_run:
-        description: 'A list of workflow(s) to run aginst ex: ["main.yml, "integration.yml"]'
+        description: 'A list of workflow(s) to run against ex: ["main.yml, "integration.yml"]'
         required: true
         type: string
 

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -1,0 +1,111 @@
+# **what?**
+# The purpose of this workflow is to trigger CI to run for each
+# release branch and main branch on a regular cadence. If the CI workflow
+# fails for a branch, it will post to dev-core-alerts to raise awareness.
+
+# **why?**
+# Ensures release branches and main are always shippable and not broken.
+# Also, can catch any dependencies shifting beneath us that might
+# introduce breaking changes (could also impact Cloud).
+
+# **when?**
+# Mainly on a schedule of 9:00, 13:00, 18:00 UTC everyday.
+# Manual trigger can also test on demand
+
+name: Release branch scheduled testing
+
+on:
+  workflow_call:
+    inputs:
+      workflows_to_run:
+        description: 'A list of workflow(s) to run aginst ex: ["main.yml, "integration.yml"]'
+        required: true
+        type: string
+
+# no special access is needed
+permissions: read-all
+
+jobs:
+  fetch-latest-branches:
+    runs-on: ubuntu-latest
+
+    outputs:
+      latest-branches: ${{ steps.get-latest-branches.outputs.repo-branches }}
+
+    steps:
+      - name: "Fetch dbt-core Latest Branches"
+        uses: dbt-labs/actions/fetch-repo-branches@v1.1.1
+        id: get-latest-branches
+        with:
+          repo_name: ${{ github.event.repository.name }}
+          organization: "dbt-labs"
+          pat: ${{ secrets.GITHUB_TOKEN }}
+          fetch_protected_branches_only: true
+          regex: "^1.[0-9]+.latest$"
+          perform_match_method: "match"
+          retries: 3
+
+      - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"
+        run: |
+          title="${{ github.event.repository.name }} - branches to test"
+          message="The workflow will run tests for the following branches of the ${{ github.event.repository.name }} repo: ${{ steps.get-latest-branches.outputs.repo-branches }}"
+          echo "::notice $title::$message"
+
+  kick-off-ci:
+    needs: [fetch-latest-branches]
+    name: Kick-off CI
+    runs-on: ubuntu-latest
+
+    strategy:
+      # must run CI 1 branch at a time b/c the workflow-dispatch polls for
+      # latest run for results and it gets confused when we kick off multiple runs
+      # at once. There is a race condition so we will just run in sequential order.
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
+        include:
+          - branch: 'main'
+        workflow_name: ${{ inputs.workflows_to_run }}
+
+    steps:
+      - name: Check out ${{ matrix.branch }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Call CI workflow for ${{ matrix.branch }} branch
+        id: trigger-step
+        run: |
+          gh workflow run ${{ matrix.workflow_name }} --ref ${{ matrix.branch }}
+        env:
+          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      - name: Get workflow run ID
+        id: workflow-id
+        run: |
+           table=$(gh run list --workflow=${{ matrix.workflow_name }})
+           echo $table
+           id=$(echo "$table" | awk 'NR==1' | jq -Rr 'split("\t")[6]')
+           echo $id
+           echo "id=$id" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      - name: Wait for run to complete
+        id: monitor-run
+        run: |
+          gh run watch ${{ steps.workflow-id.outputs.id }} --exit-status
+        env:
+          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+    # - name: Post failure to Slack
+    #   uses: ravsamhq/notify-slack-action@v2
+    #   if: ${{ always() && !contains(steps.trigger-step.outputs.workflow-conclusion,'success') }}
+    #   with:
+    #     status: ${{ job.status }}
+    #     notification_title: 'dbt-core scheduled run of "${{ matrix.branch }}" branch not successful'
+    #     message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.trigger-step.outputs.workflow-conclusion }}'
+    #     footer: 'Linked failed CI run ${{ steps.trigger-step.outputs.workflow-url }}'
+    #   env:
+    #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      latest-branches: ${{ steps.get-latest-branches.outputs.repo-branches }}
+      branches_to_test: ${{ steps.add-main.outputs.full_branch_list }}
 
     steps:
       - name: "Fetch ${{ github.event.repository.name }} Latest Branches"
@@ -53,10 +53,16 @@ jobs:
           perform_match_method: "match"
           retries: 3
 
+      - name: "Add main to branch list"
+        id: add-main
+        run: |
+          full_branch_list=(${{ steps.get-latest-branches.outputs.repo-branches }} "main")
+          echo "full_branch_list=full_branch_list" >> $GITHUB_OUTPUT
+
       - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"
         run: |
           title="${{ github.event.repository.name }} - branches to test"
-          message="The workflow will run tests in ${{ inputs.workflows_to_run }} for the following branches of the ${{ github.event.repository.name }} repo: ${{ steps.get-latest-branches.outputs.repo-branches }}"
+          message="The workflow will run tests in ${{ inputs.workflows_to_run }} for the following branches of the ${{ github.event.repository.name }} repo: ${{ steps.add-main.outputs.full_branch_list }}"
           echo "::notice $title::$message"
 
   kick-off-ci:
@@ -72,10 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         workflow_name: ${{ fromJson(inputs.workflows_to_run) }}
-        branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
-        include:
-          - branch: 'main'
-          - workflow_name: ${{ fromJson(inputs.workflows_to_run) }}
+        branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.branches_to_test) }}
 
     steps:
       - name: "[DEBUG] Print Inputs"

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -62,7 +62,8 @@ jobs:
           full_branch_list="${full_branch_list//\"/\'}"
           full_branch_list="${full_branch_list//__SINGLE_QUOTE__/\"}"
           echo $full_branch_list
-          full_branch_list=($(echo "$full_branch_list" | jq -r '.[]'))
+          # now convert it to a bash array and add the main branch
+          IFS=$'\n' read -d '' -r -a full_branch_list <<< "$(jq -r '.[]' <<< "$full_branch_list")"
           echo $full_branch_list
           full_branch_list+=("main")
           echo $full_branch_list

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"
         run: |
           title="${{ github.event.repository.name }} - branches to test"
-          message="The workflow will run tests for the following branches of the ${{ github.event.repository.name }} repo: ${{ steps.get-latest-branches.outputs.repo-branches }}"
+          message="The workflow will run tests in ${{ inputs.workflows_to_run }} for the following branches of the ${{ github.event.repository.name }} repo: ${{ steps.get-latest-branches.outputs.repo-branches }}"
           echo "::notice $title::$message"
 
   kick-off-ci:
@@ -74,7 +74,7 @@ jobs:
         branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
         include:
           - branch: 'main'
-        workflow_name: ${{ inputs.workflows_to_run }}
+        workflow_name: ["main.yml"]
 
     steps:
       - name: Check out ${{ matrix.branch }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -56,7 +56,8 @@ jobs:
       - name: "Add main to branch list"
         id: add-main
         run: |
-          full_branch_list=(${{ steps.get-latest-branches.outputs.repo-branches }} "main")
+          echo ${{ steps.get-latest-branches.outputs.repo-branches }}
+          full_branch_list=("${{ steps.get-latest-branches.outputs.repo-branches }}" "main")
           echo "full_branch_list=$full_branch_list" >> $GITHUB_OUTPUT
 
       - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -57,9 +57,10 @@ jobs:
         id: add-main
         run: |
           full_branch_list=${{ steps.get-latest-branches.outputs.repo-branches }}
-          echo $full_branch_list
-          # Swap single and double quotes using jq because bash doesnt interpret correctly
-          full_branch_list=$(jq -R 'gsub("\'\''"; "__SINGLE_QUOTE__") | gsub("\""; "'\''") | gsub("__SINGLE_QUOTE__"; "\"")' <<< "$full_branch_list")
+          # Swap single and double quotes because bash doesnt interpret correctly
+          full_branch_list="${full_branch_list//\'/__SINGLE_QUOTE__}"
+          full_branch_list="${full_branch_list//\"/'}"
+          full_branch_list="${full_branch_list//__SINGLE_QUOTE__/\"}"
           echo $full_branch_list
           full_branch_list=($(echo "$full_branch_list" | jq -r '.[]'))
           echo $full_branch_list

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -56,9 +56,10 @@ jobs:
       - name: "Add main to branch list"
         id: add-main
         run: |
-          echo ${{ steps.get-latest-branches.outputs.repo-branches }}
+          full_branch_list=${{ steps.get-latest-branches.outputs.repo-branches }}
+          echo $full_branch_list
           # Swap single and double quotes using jq because bash doesnt interpret correctly
-          full_branch_list=$(jq -R 'gsub("\'\''"; "__SINGLE_QUOTE__") | gsub("\""; "'\''") | gsub("__SINGLE_QUOTE__"; "\"")' <<< "${{ steps.get-latest-branches.outputs.repo-branches }}")
+          full_branch_list=$(jq -R 'gsub("\'\''"; "__SINGLE_QUOTE__") | gsub("\""; "'\''") | gsub("__SINGLE_QUOTE__"; "\"")' <<< "$full_branch_list")
           echo $full_branch_list
           full_branch_list=($(echo "$full_branch_list" | jq -r '.[]'))
           echo $full_branch_list

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -65,7 +65,7 @@ jobs:
           full_branch_list="${full_branch_list//__SINGLE_QUOTE__/\"}"
           echo $full_branch_list
           # now convert it to a bash array and add the main branch
-          IFS=$'\n' read -d '' -r -a full_branch_list <<< "$(jq -r '.[]' <<< "$full_branch_list")"
+          IFS=$'\n' read -d '' -r -a full_branch_list <<< "$(jq -r '.[]' <<< $full_branch_list)"
           for item in "${full_branch_list[@]}"; do   echo "$item"; done
           full_branch_list+=("main")
           for item in "${full_branch_list[@]}"; do   echo "$item"; done

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -59,17 +59,18 @@ jobs:
           full_branch_list="${{ steps.get-latest-branches.outputs.repo-branches }}"
           # Swap single and double quotes because bash doesnt interpret correctly
           full_branch_list="${full_branch_list//\'/__SINGLE_QUOTE__}"
-          echo $full_branch_list
           full_branch_list="${full_branch_list//\"/\'}"
-          echo $full_branch_list
           full_branch_list="${full_branch_list//__SINGLE_QUOTE__/\"}"
-          echo $full_branch_list
           # now convert it to a bash array and add the main branch
           full_branch_list=($(echo "$full_branch_list" | jq -r '.[]'))
           for item in "${full_branch_list[@]}"; do   echo "$item"; done
           full_branch_list+=("main")
-          for item in "${full_branch_list[@]}"; do   echo "$item"; done
-          echo "full_branch_list=$full_branch_list" >> $GITHUB_OUTPUT
+          # Convert the array to a string
+          full_branch_list_string=$(printf "'%s', " "${full_branch_list[@]}")
+          full_branch_list_string="[${full_branch_list_string%, }]"
+          # Assign the string to a variable
+          echo $full_branch_list_string
+          echo "full_branch_list=$full_branch_list_string" >> $GITHUB_OUTPUT
 
       - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"
         run: |

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -57,7 +57,7 @@ jobs:
         id: add-main
         run: |
           echo ${{ steps.get-latest-branches.outputs.repo-branches }}
-          full_branch_list=${{ fromJSON(steps.get-latest-branches.outputs.repo-branches) }}
+          full_branch_list=($(echo "${{ fromJSON(steps.get-latest-branches.outputs.repo-branches) }}" | jq -r '.[]'))
           full_branch_list+="main"
           echo $full_branch_list
           echo "full_branch_list=$full_branch_list" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -99,43 +99,43 @@ jobs:
           echo "matrix.branch:           ${{ matrix.branch }}"
           echo "matrix.workflow_name:    ${{ matrix.workflow_name }}"
 
-      # - name: Check out ${{ matrix.branch }}
-      #   uses: actions/checkout@v3
-      #   with:
-      #     ref: ${{ matrix.branch }}
+      - name: Check out ${{ matrix.branch }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
 
-      # - name: Call CI workflow for ${{ matrix.branch }} branch
-      #   id: trigger-step
-      #   run: |
-      #     gh workflow run ${{ matrix.workflow_name }} --ref ${{ matrix.branch }}
-      #   env:
-      #     GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+      - name: Call CI workflow for ${{ matrix.branch }} branch
+        id: trigger-step
+        run: |
+          gh workflow run ${{ matrix.workflow_name }} --ref ${{ matrix.branch }}
+        env:
+          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
 
-      # - name: Get workflow run ID
-      #   id: workflow-id
-      #   run: |
-      #      table=$(gh run list --workflow=${{ matrix.workflow_name }})
-      #      echo $table
-      #      id=$(echo "$table" | awk 'NR==1' | jq -Rr 'split("\t")[6]')
-      #      echo $id
-      #      echo "id=$id" >> $GITHUB_OUTPUT
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get workflow run ID
+        id: workflow-id
+        run: |
+           table=$(gh run list --workflow=${{ matrix.workflow_name }})
+           echo $table
+           id=$(echo "$table" | awk 'NR==1' | jq -Rr 'split("\t")[6]')
+           echo $id
+           echo "id=$id" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Wait for run to complete
-      #   id: monitor-run
-      #   run: |
-      #     gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for run to complete
+        id: monitor-run
+        run: |
+          gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # - name: Post failure to Slack
-    #   uses: ravsamhq/notify-slack-action@v2
-    #   if: ${{ always() && !contains(steps.trigger-step.outputs.workflow-conclusion,'success') }}
-    #   with:
-    #     status: ${{ job.status }}
-    #     notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
-    #     message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.trigger-step.outputs.workflow-conclusion }}'
-    #     footer: 'Linked failed CI run ${{ steps.trigger-step.outputs.workflow-url }}'
-    #   env:
-    #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
+      - name: Post failure to Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: ${{ always() && !contains(steps.trigger-step.outputs.workflow-conclusion,'success') }}
+        with:
+          status: ${{ job.status }}
+          notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
+          message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.trigger-step.outputs.workflow-conclusion }}'
+          footer: 'Linked failed CI run ${{ steps.trigger-step.outputs.workflow-url }}'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -124,15 +124,14 @@ jobs:
 
       - name: Wait for run to complete
         id: monitor-run
-        continue-on-error: true
         run: |
-          gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
+          # gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
           exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get slack message details for failed runs
-        if: ${{ steps.monitor-run.outcome != 'success' }}
+        if: ${{ always() && steps.monitor-run.outcome != 'success' }}
         id: status-check
         run: |
           url=$(gh run view ${{ steps.workflow-id.outputs.id }} --json url -q ".url")
@@ -142,7 +141,7 @@ jobs:
 
       - name: Post failure to Slack
         uses: ravsamhq/notify-slack-action@v2
-        if: ${{ steps.monitor-run.outcome != 'success' }}
+        if: ${{ always() && steps.monitor-run.outcome != 'success' }}
         with:
           status: ${{ job.status }}
           # notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -64,9 +64,9 @@ jobs:
           echo $full_branch_list
           # now convert it to a bash array and add the main branch
           IFS=$'\n' read -d '' -r -a full_branch_list <<< "$(jq -r '.[]' <<< "$full_branch_list")"
-          echo $full_branch_list
+          for item in "${full_branch_list[@]}"; do   echo "$item"; done
           full_branch_list+=("main")
-          echo $full_branch_list
+          for item in "${full_branch_list[@]}"; do   echo "$item"; done
           echo "full_branch_list=$full_branch_list" >> $GITHUB_OUTPUT
 
       - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         workflow_name: ${{ fromJson(inputs.workflows_to_run) }}
-        branch: ['1.5.latest']
+        branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.branches_to_test) }}
 
     steps:
       - name: "[DEBUG] Print Inputs"


### PR DESCRIPTION
The marketplace workflow that we had been using has been abandoned so it needed to be replaced.

This centralizes the release branch testing for core and all adapters.