### PR TITLE
fix some errors with jira actions

### DIFF
--- a/.github/workflows/jira-creation.yml
+++ b/.github/workflows/jira-creation.yml
@@ -82,7 +82,7 @@ jobs:
     needs:
       - create-issue
     outputs:
-      labels: ${{ steps.generate-labels.outputs.labels }}
+      json_labels: ${{ steps.generate-labels.outputs.labels }}
     steps:
       - name: Generate Labels
         id: generate-labels
@@ -95,13 +95,14 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
   add-labels:
+    if: needs.find-labels.outputs.json_labels != '[]'
     runs-on: ubuntu-latest
     needs:
       - create-issue
       - find-labels
     strategy:
       matrix:
-        label: ${{ fromJSON(needs.find-labels.outputs.labels) }}
+        label: ${{ fromJSON(needs.find-labels.outputs.json_labels) }}
     steps:
       - name: "[DEBUG] - Print Job Inputs"
         shell: bash

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -45,8 +45,10 @@ jobs:
         env:
           TITLE: "${{ github.event.issue.title }}"
         run: |
-          issueId=$(echo -n $TITLE | awk '{print $1}' | awk -F'[][]' '{print $2}')
-          echo "issueId=${issueId}" >> $GITHUB_OUTPUT
+          echo $TITLE
+          extracted_issue=${TITLE#\[}
+          extracted_issue=${extracted_issue%%]*}
+          echo "issueId=${extracted_issue}" >> $GITHUB_OUTPUT
 
   edit-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -46,11 +46,11 @@ jobs:
           TITLE: "${{ github.event.issue.title }}"
         run: |
           echo $TITLE
-          extracted_issue=${TITLE#\[}
-          extracted_issue=${extracted_issue%%]*}
-          echo "issueId=${extracted_issue}" >> $GITHUB_OUTPUT
+          issueId=$(echo -n $TITLE | awk '{print $1}' | awk -F'[][]' '{print $2}')
+          echo "issueId=${issueId}" >> $GITHUB_OUTPUT
 
   edit-label:
+    if: needs.extract-id.outputs.issueId != ''
     runs-on: ubuntu-latest
     needs: extract-id
     env:


### PR DESCRIPTION
Resolve #50 
Resolves #102 

Fixes some issues with triggering.

1. `jira-label` fails often because it runs when a PR is opened but fails because the `jira-creation` workflow hasn't finished adding the issue so it doesn't have an issue id to work off.  `jira-creation` already syncs the labels so it's okay to skip this one if there is no issue id yet.
2. `jira-creation` fails when an issue is created with no labels.  The issue is still mirrored into Jira but the workflows ends with a failed status because the last step fails.