### PR TITLE
add wait

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -115,6 +115,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
 
+      # If you check for running workflows too fast, the one just submitted won't be there yet
+      - name: "Wait for it"
+        id: waiting
+        run: |
+          sleep 5s
+
       - name: Get workflow run ID
         id: workflow-id
         run: |

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -119,12 +119,12 @@ jobs:
       - name: "Wait for it"
         id: waiting
         run: |
-          sleep 5s
+          sleep 25s
 
       - name: Get workflow run ID
         id: workflow-id
         run: |
-           table=$(gh run list --workflow=${{ matrix.workflow_name }})
+           table=$(gh run list --workflow=${{ matrix.workflow_name }} --branch=${{ matrix.branch }} --event=workflow_dispatch)
            echo $table
            id=$(echo "$table" | awk 'NR==1' | jq -Rr 'split("\t")[6]')
            echo $id


### PR DESCRIPTION
resolve #105 

Looking at the table of workflows returned by 

```
table=$(gh run list --workflow=${{ matrix.workflow_name }})
```

it does not even include the submitted workflow.  This sleep allows time for the request to go through before checking for the status.