### PR TITLE
Excluding 1.5 from testing with py3.7

### DIFF
--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -93,6 +93,8 @@ jobs:
             python-version: 3.9
           - branch: "1.0.latest"
             python-version: 3.10
+          - branch: "1.5.latest"
+            python-version: 3.7
 
     steps:
       - name: "Resolve Repository"


### PR DESCRIPTION
We don't support python 3.7 with 1.5+ now so excluding it from the test matrix