### PR TITLE
Split adapter and core alerts

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -150,21 +150,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set slack webhook
-        run: |
-          if [[ ${{ github.event.repository.name }} == "dbt-core" ]]; then
-              echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_DEV_CORE_ALERTS }}" >> "$GITHUB_ENV"
-          else
-              echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_DEV_ADAPTER_ALERTS }}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Post failure to Slack
+      - name: Post failure to core Slack
         uses: ravsamhq/notify-slack-action@v2
-        if: ${{ always() && steps.monitor-run.outcome != 'success' }}
+        if: ${{ always() && steps.monitor-run.outcome != 'success' && github.event.repository.name == "dbt-core" }}
         with:
           status: ${{ job.status }}
           notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
           message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
           footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
         env:
-          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
+
+      - name: Post failure to adapter Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: ${{ always() && steps.monitor-run.outcome != 'success' && github.event.repository.name != "dbt-core" }}
+        with:
+          status: ${{ job.status }}
+          notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
+          message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
+          footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -35,14 +35,12 @@ jobs:
           echo "workflows_to_run:    ${{ inputs.workflows_to_run }}"
 
       - name: Set slack webhook
-        if: ${{ github.event.repository.name == dbt-core }}
         run: |
-          echo ${{ secrets.SLACK_DEV_CORE_ALERTS }} >> $SLACK_WEBHOOK_URL
-
-      - name: Set slack webhook
-        if: ${{ github.event.repository.name != dbt-core }}
-        run: |
-          echo ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }} >> $SLACK_WEBHOOK_URL
+          if [[ ${{ github.event.repository.name }} == "dbt-core" ]]; then
+              echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_DEV_CORE_ALERTS }}" >> "$GITHUB_ENV"
+          else
+              echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_DEV_ADAPTER_ALERTS }}" >> "$GITHUB_ENV"
+          fi
 
   fetch-latest-branches:
     runs-on: ubuntu-latest
@@ -169,4 +167,4 @@ jobs:
           message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
           footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
         env:
-          SLACK_WEBHOOK_URL: $SLACK_WEBHOOK_URL
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -21,9 +21,9 @@ on:
         description: 'A list of workflow(s) to run against ex: ["main.yml, "integration.yml"]'
         required: true
         type: string
-      alert_webhook:
-        description: 'Webhook url to post alerts to'
-        required: true
+      alerts:
+        description: 'Where to post alerts in slack. Choose either "adapters" or "core". Default=core'
+        required: false
         type: string
 
 # no special access is needed
@@ -37,6 +37,18 @@ jobs:
       - name: "[DEBUG] Print Inputs"
         run: |
           echo "workflows_to_run:    ${{ inputs.workflows_to_run }}"
+
+      - name: Set slack webhook
+        if: ${{ inputs.alerts == "adapters" }}
+        run: |
+          echo ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }} >> $SLACK_WEBHOOK_URL
+        if: startsWith(github.ref, 'refs/tags/release-')
+
+      - name: Set slack webhook
+        if: ${{ inputs.alerts != "adapters" }}
+        run: |
+          echo ${{ secrets.SLACK_DEV_CORE_ALERTS }} >> $SLACK_WEBHOOK_URL
+        if: startsWith(github.ref, 'refs/tags/release-')
 
   fetch-latest-branches:
     runs-on: ubuntu-latest
@@ -163,4 +175,4 @@ jobs:
           message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
           footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
         env:
-          SLACK_WEBHOOK_URL: ${{ inputs.alert_webhook }}
+          SLACK_WEBHOOK_URL: $SLACK_WEBHOOK_URL

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -34,14 +34,6 @@ jobs:
         run: |
           echo "workflows_to_run:    ${{ inputs.workflows_to_run }}"
 
-      - name: Set slack webhook
-        run: |
-          if [[ ${{ github.event.repository.name }} == "dbt-core" ]]; then
-              echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_DEV_CORE_ALERTS }}" >> "$GITHUB_ENV"
-          else
-              echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_DEV_ADAPTER_ALERTS }}" >> "$GITHUB_ENV"
-          fi
-
   fetch-latest-branches:
     runs-on: ubuntu-latest
 
@@ -157,6 +149,14 @@ jobs:
           echo "workflow-conclusion=$conclusion" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set slack webhook
+        run: |
+          if [[ ${{ github.event.repository.name }} == "dbt-core" ]]; then
+              echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_DEV_CORE_ALERTS }}" >> "$GITHUB_ENV"
+          else
+              echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_DEV_ADAPTER_ALERTS }}" >> "$GITHUB_ENV"
+          fi
 
       - name: Post failure to Slack
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Post failure to core Slack
         uses: ravsamhq/notify-slack-action@v2
-        if: ${{ always() && steps.monitor-run.outcome != 'success' && github.event.repository.name == "dbt-core" }}
+        if: ${{ always() && steps.monitor-run.outcome != 'success' && github.event.repository.name == 'dbt-core' }}
         with:
           status: ${{ job.status }}
           notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'
@@ -163,7 +163,7 @@ jobs:
 
       - name: Post failure to adapter Slack
         uses: ravsamhq/notify-slack-action@v2
-        if: ${{ always() && steps.monitor-run.outcome != 'success' && github.event.repository.name != "dbt-core" }}
+        if: ${{ always() && steps.monitor-run.outcome != 'success' && github.event.repository.name != 'dbt-core' }}
         with:
           status: ${{ job.status }}
           notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -21,10 +21,6 @@ on:
         description: 'A list of workflow(s) to run against ex: ["main.yml, "integration.yml"]'
         required: true
         type: string
-      alerts:
-        description: 'Where to post alerts in slack. Choose either "adapters" or "core". Default=core'
-        required: false
-        type: string
 
 # no special access is needed
 permissions: read-all
@@ -39,16 +35,14 @@ jobs:
           echo "workflows_to_run:    ${{ inputs.workflows_to_run }}"
 
       - name: Set slack webhook
-        if: ${{ inputs.alerts == "adapters" }}
-        run: |
-          echo ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }} >> $SLACK_WEBHOOK_URL
-        if: startsWith(github.ref, 'refs/tags/release-')
-
-      - name: Set slack webhook
-        if: ${{ inputs.alerts != "adapters" }}
+        if: ${{ github.event.repository.name == dbt-core }}
         run: |
           echo ${{ secrets.SLACK_DEV_CORE_ALERTS }} >> $SLACK_WEBHOOK_URL
-        if: startsWith(github.ref, 'refs/tags/release-')
+
+      - name: Set slack webhook
+        if: ${{ github.event.repository.name != dbt-core }}
+        run: |
+          echo ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }} >> $SLACK_WEBHOOK_URL
 
   fetch-latest-branches:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -21,9 +21,9 @@ on:
         description: 'A list of workflow(s) to run against ex: ["main.yml, "integration.yml"]'
         required: true
         type: string
-      alerts:
-        description: 'Where to post alerts in slack. Choose either "adapters" or "core". Default=core'
-        required: false
+      alert_webhook:
+        description: 'Webhook url to post alerts to'
+        required: true
         type: string
 
 # no special access is needed
@@ -37,18 +37,6 @@ jobs:
       - name: "[DEBUG] Print Inputs"
         run: |
           echo "workflows_to_run:    ${{ inputs.workflows_to_run }}"
-
-      - name: Set slack webhook
-        if: ${{ inputs.alerts == "adapters" }}
-        run: |
-          echo ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }} >> $SLACK_WEBHOOK_URL
-        if: startsWith(github.ref, 'refs/tags/release-')
-
-      - name: Set slack webhook
-        if: ${{ inputs.alerts != "adapters" }}
-        run: |
-          echo ${{ secrets.SLACK_DEV_CORE_ALERTS }} >> $SLACK_WEBHOOK_URL
-        if: startsWith(github.ref, 'refs/tags/release-')
 
   fetch-latest-branches:
     runs-on: ubuntu-latest
@@ -175,4 +163,4 @@ jobs:
           message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
           footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
         env:
-          SLACK_WEBHOOK_URL: $SLACK_WEBHOOK_URL
+          SLACK_WEBHOOK_URL: ${{ inputs.alert_webhook }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -21,6 +21,10 @@ on:
         description: 'A list of workflow(s) to run against ex: ["main.yml, "integration.yml"]'
         required: true
         type: string
+      alerts:
+        description: 'Where to post alerts in slack. Choose either "adapters" or "core". Default=core'
+        required: false
+        type: string
 
 # no special access is needed
 permissions: read-all
@@ -33,6 +37,18 @@ jobs:
       - name: "[DEBUG] Print Inputs"
         run: |
           echo "workflows_to_run:    ${{ inputs.workflows_to_run }}"
+
+      - name: Set slack webhook
+        if: ${{ inputs.alerts == "adapters" }}
+        run: |
+          echo ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }} >> $SLACK_WEBHOOK_URL
+        if: startsWith(github.ref, 'refs/tags/release-')
+
+      - name: Set slack webhook
+        if: ${{ inputs.alerts != "adapters" }}
+        run: |
+          echo ${{ secrets.SLACK_DEV_CORE_ALERTS }} >> $SLACK_WEBHOOK_URL
+        if: startsWith(github.ref, 'refs/tags/release-')
 
   fetch-latest-branches:
     runs-on: ubuntu-latest
@@ -159,4 +175,4 @@ jobs:
           message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.status-check.outputs.workflow-conclusion }}'
           footer: 'Linked failed CI run ${{ steps.status-check.outputs.workflow-url }}'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
+          SLACK_WEBHOOK_URL: $SLACK_WEBHOOK_URL


### PR DESCRIPTION
[BigQuery references this action](https://github.com/dbt-labs/dbt-bigquery/blob/main/.github/workflows/release-branch-tests.yml), but needs to post the alerts to a different channel.

This change branches on the calling repository to send alerts to core if the calling repo is dbt-core, and to adapters otherwise.