### PR TITLE
Remove reference to core team from `swap-labels.yml`

### DIFF
--- a/.github/workflows/swap-labels.yml
+++ b/.github/workflows/swap-labels.yml
@@ -2,7 +2,7 @@
 # Will remove one label in favor of another
 #
 # **why?**
-# When the we triage issues, we sometimes need more information from the issue creator.  In
+# When we triage issues, we sometimes need more information from the issue creator.  In
 # those cases we remove the `triage` label and add the `awaiting_response` label.  Once we
 # receive a response in the form of a comment, we want the `awaiting_response` label removed
 # in favor of the `triage` label so we are aware that the issue needs action.

--- a/.github/workflows/swap-labels.yml
+++ b/.github/workflows/swap-labels.yml
@@ -4,7 +4,7 @@
 # **why?**
 # When the we triage issues, we sometimes need more information from the issue creator.  In
 # those cases we remove the `triage` label and add the `awaiting_response` label.  Once we
-# recieve a response in the form of a comment, we want the `awaiting_response` label removed
+# receive a response in the form of a comment, we want the `awaiting_response` label removed
 # in favor of the `triage` label so we are aware that the issue needs action.
 
 # **when?**

--- a/.github/workflows/swap-labels.yml
+++ b/.github/workflows/swap-labels.yml
@@ -2,7 +2,7 @@
 # Will remove one label in favor of another
 #
 # **why?**
-# When the core team triages, we sometimes need more information from the issue creator.  In
+# When the we triage issues, we sometimes need more information from the issue creator.  In
 # those cases we remove the `triage` label and add the `awaiting_response` label.  Once we
 # recieve a response in the form of a comment, we want the `awaiting_response` label removed
 # in favor of the `triage` label so we are aware that the issue needs action.


### PR DESCRIPTION
## Motivation

Two things:
- Make the description for the action generic rather than a specific reference to the dbt Core team
- Fix a spelling mistake