### PR TITLE
Add a job to convert all stale PRs to draft status

### DIFF
--- a/.github/workflows/stale-bot-matrix.yml
+++ b/.github/workflows/stale-bot-matrix.yml
@@ -1,5 +1,5 @@
 # **what?**
-# For issues that have been open for awhile without activity, label
+# For issues that have been open for a while without activity, label
 # them as stale with a warning that they will be closed out. If
 # anyone comments to keep the issue open, it will automatically
 # remove the stale label and keep it open.
@@ -83,3 +83,14 @@ jobs:
           close-issue-reason: ${{ env.CLOSE_ISSUE_REASON }}
           days-before-stale: 180
           exempt-issue-labels: 'tech_debt,good_first_issue,help_wanted'
+
+  mark-as-draft:
+    name: Mark stale PRs as Draft status
+    if: ${{ (github.event.pull_request.draft == false) && contains(github.event.pull_request.labels.*.name, 'stale') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark as Draft
+        # https://github.com/voiceflow/draft-pr
+        uses: voiceflow/draft-pr@v1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We decided that we want to convert stale PRs to Draft status to indicate that they do not need to be reviewed in their current state. This would streamline the workflow for those PRs which do need attention by removing the noise. We would like to automate this instead of doing this manually during support rotation.

For those reviewing this PR, I have two key questions:
- Is this the correct syntax (it's difficult to test this)?
- Should this be embedded in the stale workflow or live as its own workflow?