### PR TITLE
Update open-issue-in-repo.yml to use PR author

### DIFF
--- a/.github/workflows/open-issue-in-repo.yml
+++ b/.github/workflows/open-issue-in-repo.yml
@@ -108,7 +108,7 @@ jobs:
           issue=$(gh issue create --repo ${{ inputs.issue_repository }} \
             --title "${{ inputs.issue_title }}" \
             --body "${{ inputs.issue_body }}" \
-            --assignee ${{ github.actor }} ${{ steps.labels.outputs.labels }})
+            --assignee ${{ github.event.pull_request.user.login }} ${{ steps.labels.outputs.labels }})
           echo "issue_url=$issue" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}


### PR DESCRIPTION
Replaces actor with PR author.  If we use the actor it will be the one that either hits the merge button or adds the `user docs` label.

Ideally the PR author can add the context needed or tag someone else in.