### PR TITLE
remove labels and assignees

### DIFF
--- a/.github/workflows/open-issue-in-repo.yml
+++ b/.github/workflows/open-issue-in-repo.yml
@@ -29,6 +29,11 @@ on:
         required: true
         type: string
         default: "This is a test issue opened from another workflow."
+      pr_number:
+        description: 'The PR to open the issue from'
+        required: true
+        type: string
+        default: "133"
 
   workflow_call:
     inputs:
@@ -62,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       exists: ${{ steps.comment_check.outputs.exists }}
+      pr_number: ${{ steps.pr_values.outputs.pr_number }}
 
     steps:
 
@@ -71,13 +77,22 @@ jobs:
           echo "inputs.issue_repository:      ${{ inputs.issue_repository }}"
           echo "inputs.issue_title:           ${{ inputs.issue_title}}"
           echo "inputs.issue_body:            ${{ inputs.issue_body }}"
+
+      - name: "Determine PR values"
+        id: pr_values
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "pr_number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
       
       # this step uses the read permission from the GITHUB_TOKEN it inherits
       - name: "Check for comment"
         uses: peter-evans/find-comment@v2
         id: pr_comment
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ steps.pr_values.outputs.pr_number }}
           comment-author: "FishtownBuildBot"
           body-includes: "Opened a new issue in ${{ inputs.issue_repository }}:"
 
@@ -126,7 +141,7 @@ jobs:
         id: pr_comment
         run: |
           gh pr comment --repo ${{ github.repository }} \
-            ${{ github.event.pull_request.number }} \
+            ${{ needs.prep.outputs.pr_number }} \
             --body "${{ steps.set_pr_comment.outputs.pr_comment }}"
         env:
           GITHUB_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}

--- a/.github/workflows/open-issue-in-repo.yml
+++ b/.github/workflows/open-issue-in-repo.yml
@@ -18,7 +18,7 @@ on:
         description: 'Repository to open the issue in'
         required: true
         type: string
-        default: dbt-docs
+        default: dbt-labs/dbt-docs
       issue_title:
         description: 'Title of the issue'
         required: true

--- a/.github/workflows/open-issue-in-repo.yml
+++ b/.github/workflows/open-issue-in-repo.yml
@@ -78,7 +78,7 @@ jobs:
         id: pr_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
+          comment-author: "FishtownBuildBot"
           body-includes: "Opened a new issue in ${{ inputs.issue_repository }}:"
 
       - name: "Set if comment already exists"

--- a/.github/workflows/open-issue-in-repo.yml
+++ b/.github/workflows/open-issue-in-repo.yml
@@ -19,11 +19,6 @@ on:
         required: true
         type: string
         default: dbt-docs
-      issue_labels:
-        description: 'Labels to add to the issue'
-        required: false
-        type: string
-        default: "content,improvement,dbt Core"
       issue_title:
         description: 'Title of the issue'
         required: true
@@ -40,10 +35,6 @@ on:
       issue_repository:
         description: 'Repository to open the issue in'
         required: true
-        type: string
-      issue_labels:
-        description: 'Labels to add to the issue'
-        required: false
         type: string
       issue_title:
         description: 'Title of the issue'
@@ -78,7 +69,6 @@ jobs:
         id: print_variables
         run: |
           echo "inputs.issue_repository:      ${{ inputs.issue_repository }}"
-          echo "inputs.issue_labels:          ${{ inputs.issue_labels }}"
           echo "inputs.issue_title:           ${{ inputs.issue_title}}"
           echo "inputs.issue_body:            ${{ inputs.issue_body }}"
       
@@ -115,20 +105,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
-      
-      - name: "Set labels"
-        if: ${{ inputs.issue_labels }}
-        id: labels
-        run: |
-          echo "labels=--label '${{ inputs.issue_labels }}'" >> $GITHUB_OUTPUT
 
       - name: "Open Issue in ${{ inputs.issue_repository }}"
         id: open_issue
         run: |
           issue=$(gh issue create --repo ${{ inputs.issue_repository }} \
             --title "${{ inputs.issue_title }}" \
-            --body "${{ inputs.issue_body }}" \
-            --assignee ${{ github.event.pull_request.user.login }} ${{ steps.labels.outputs.labels }})
+            --body "${{ inputs.issue_body }}")
           echo "issue_url=$issue" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}

--- a/.github/workflows/open-issue-in-repo.yml
+++ b/.github/workflows/open-issue-in-repo.yml
@@ -101,12 +101,12 @@ jobs:
         run: |
           if [ '${{ steps.pr_comment.outputs.comment-body }}' = '' ]; then
             echo "exists=false" >> $GITHUB_OUTPUT
-            title="Comment does not exist for this PR."
+            title="Continue Processing."
             message="Opening a new issue in ${{ inputs.issue_repository }}."
           else
             echo "exists=true" >> $GITHUB_OUTPUT
-            title="Comment already exists for this PR indicating associated issue."
-            message="New issue will not be opened."
+            title="Stop processing."
+            message="Comment already exists for this PR indicating associated issue. New issue will not be opened."
           fi
           echo "::notice $title::$message"
 


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/8439

Removes label and assignee values from issue creation.  This is due to a scoped permission issue with github workflows.   Additionally, this adds the ability to test this workflow by inputting a PR number.

For the destination repo to add labels and/or assignee, they must trigger a workflow in their own repository.

This PR is tightly tied to https://github.com/dbt-labs/dbt-core/pull/8557