### PR TITLE
Reusable Workflow to Cleanup Repos

### DIFF
--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -6,7 +6,7 @@
 # Our release process leaves behind branches and draft releases that are cluttering up the repo.
 
 # **when?**
-# As scheduled by calling workflow_dispatch.
+# As scheduled by calling workflow_call.
 
 name: Release Cleanup
 
@@ -31,9 +31,6 @@ jobs:
         with:
           repository: ${{ github.repository }}
           fetch-depth: 0
-      
-      - name: "Check status"
-        run: git status
 
       - name: "List Branch to be Deleted for: ${{ matrix.branch }}"
         run: |
@@ -45,12 +42,12 @@ jobs:
             git push origin --delete $b
           done
 
-      - name: "[Sanity Check] List Branch matching: ${{ matrix.branch }}"
+      - name: "[Expect None] List Branch matching: ${{ matrix.branch }}"
         run: |
           git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'
 
   delete-draft-releases:
-    name: "Delete Draft Releases"
+    name: "Delete Draft Releases in ${{ github.repository }}"
     runs-on: ubuntu-latest
     steps:
       
@@ -69,7 +66,7 @@ jobs:
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: "[Sanity Check] List Draft Releases"
+      - name: "[Expect None] List Draft Releases"
         run: |
           gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'
         env: 

--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -10,20 +10,12 @@
 
 name: Release Cleanup
 
-on:
-  workflow_dispatch:
+on: workflow_call
 
-# TODO: this is a guess
 permissions:
   contents: write
 
 jobs:
-  debug:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "[DEBUG] Inputs"
-        run: |
-          echo 
 
   delete-branches:
     name: "Delete ${{ matrix.branch }} Branches"
@@ -39,14 +31,42 @@ jobs:
         with:
           repository: ${{ github.repository }}
 
-      - name: "Deal with Branches Matching ${{ matrix.branch }}"
+      - name: "List Branch to be Deleted for: ${{ matrix.branch }}"
         run: |
-          echo ${{ matrix.branch }}
+          git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'
+
+      - name: "Delete Prerelease Branches: ${{ matrix.branch }}"
+        run: |
+          for b in $(git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'); do
+            git push origin --delete $b
+          done
+
+      - name: "[Sanity Check] List Branch matching: ${{ matrix.branch }}"
+        run: |
+          git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'
 
   delete-draft-releases:
     name: "Delete Draft Releases"
     runs-on: ubuntu-latest
     steps:
-    - name: "Deal with draft releases"
-      run: |
-        echo "TODO"
+      
+      - name: "List Draft Releases"
+        run: |
+          gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Delete Draft Releases in ${{ github.repository }}"
+        run: |
+          for release in $(gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'); do
+            echo "Deleting Draft Release: $release"
+            gh release --repo ${{ github.repository }} delete --yes $release
+          done
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: "[Sanity Check] List Draft Releases"
+        run: |
+          gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -1,0 +1,52 @@
+# **what?**
+# Release cleanup.
+# Cleans up both branches and draft releases left over from test and pre releases.
+#
+# **why?**
+# Our release process leaves behind branches and draft releases that are cluttering up the repo.
+
+# **when?**
+# As scheduled by calling workflow_dispatch.
+
+name: Release Cleanup
+
+on:
+  workflow_dispatch:
+
+# TODO: this is a guess
+permissions:
+  contents: write
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[DEBUG] Inputs"
+        run: |
+          echo 
+
+  delete-branches:
+    name: "Delete ${{ matrix.branch }} Branches"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: ["cutting_release_branch/*", "prep-release/*"]
+
+    steps:
+      - name: "Check out ${{ github.repository }}"
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository }}
+
+      - name: "Deal with Branches Matching ${{ matrix.branch }}"
+        run: |
+          echo ${{ matrix.branch }}
+
+  delete-draft-releases:
+    name: "Delete Draft Releases"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Deal with draft releases"
+      run: |
+        echo "TODO"

--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -30,6 +30,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
+          fetch-depth: 0
+      
+      - name: "Check status"
+        run: git status
 
       - name: "List Branch to be Deleted for: ${{ matrix.branch }}"
         run: |

--- a/.github/workflows/swap-labels.yml
+++ b/.github/workflows/swap-labels.yml
@@ -1,73 +1,61 @@
 # **what?**
-# Release cleanup.
-# Cleans up both branches and draft releases left over from test and pre releases.
+# Will remove one label in favor of another
 #
 # **why?**
-# Our release process leaves behind branches and draft releases that are cluttering up the repo.
+# When we triage issues, we sometimes need more information from the issue creator.  In
+# those cases we remove the `triage` label and add the `awaiting_response` label.  Once we
+# receive a response in the form of a comment, we want the `awaiting_response` label removed
+# in favor of the `triage` label so we are aware that the issue needs action.
 
 # **when?**
-# As scheduled by calling workflow_dispatch.
+# This will run when called by another workflow
 
-name: Release Cleanup
+name: Swap Issue Labels
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      add_label:
+        description: The label to add
+        type: string
+        required: true
+      remove_label:
+        description: The label to remove
+        type: string
+        required: true
+
+defaults:
+  run:
+    shell: bash
 
 permissions:
-  contents: write
+  issues: write
 
 jobs:
-
-  delete-branches:
-    name: "Delete ${{ matrix.branch }} Branches"
+  triage_label:
+    # only swap the labels if the label to remove exists
+    if: contains(github.event.issue.labels.*.name, '${{ inputs.remove_label }}')
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        branch: ["cutting_release_branch/*", "prep-release/*"]
-
     steps:
-      - name: "Check out ${{ github.repository }}"
-        uses: actions/checkout@v3
+      - name: "Add ${{ inputs.add_label }} label"
+        uses: actions/github-script@v6
         with:
-          repository: ${{ github.repository }}
-          fetch-depth: 0
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["${{ inputs.add_label }}"]
+            })
 
-      - name: "List Branch to be Deleted for: ${{ matrix.branch }}"
-        run: |
-          git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'
-
-      - name: "Delete Prerelease Branches: ${{ matrix.branch }}"
-        run: |
-          for b in $(git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'); do
-            git push origin --delete $b
-          done
-
-      - name: "[Expect None] List Branch matching: ${{ matrix.branch }}"
-        run: |
-          git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'
-
-  delete-draft-releases:
-    name: "Delete Draft Releases in ${{ github.repository }}"
-    runs-on: ubuntu-latest
-    steps:
-      
-      - name: "List Draft Releases"
-        run: |
-          gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Delete Draft Releases in ${{ github.repository }}"
-        run: |
-          for release in $(gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'); do
-            echo "Deleting Draft Release: $release"
-            gh release --repo ${{ github.repository }} delete --yes $release
-          done
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: "[Expect None] List Draft Releases"
-        run: |
-          gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Remove ${{ inputs.remove_label }} label"
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ["${{ inputs.remove_label }}"]
+            })

--- a/.github/workflows/swap-labels.yml
+++ b/.github/workflows/swap-labels.yml
@@ -1,61 +1,72 @@
 # **what?**
-# Will remove one label in favor of another
+# Release cleanup.
+# Cleans up both branches and draft releases left over from test and pre releases.
 #
 # **why?**
-# When we triage issues, we sometimes need more information from the issue creator.  In
-# those cases we remove the `triage` label and add the `awaiting_response` label.  Once we
-# receive a response in the form of a comment, we want the `awaiting_response` label removed
-# in favor of the `triage` label so we are aware that the issue needs action.
+# Our release process leaves behind branches and draft releases that are cluttering up the repo.
 
 # **when?**
-# This will run when called by another workflow
+# As scheduled by calling workflow_dispatch.
 
-name: Swap Issue Labels
+name: Release Cleanup
 
-on:
-  workflow_call:
-    inputs:
-      add_label:
-        description: The label to add
-        type: string
-        required: true
-      remove_label:
-        description: The label to remove
-        type: string
-        required: true
-
-defaults:
-  run:
-    shell: bash
+on: workflow_call
 
 permissions:
-  issues: write
+  contents: write
 
 jobs:
-  triage_label:
-    # only swap the labels if the label to remove exists
-    if: contains(github.event.issue.labels.*.name, '${{ inputs.remove_label }}')
+
+  delete-branches:
+    name: "Delete ${{ matrix.branch }} Branches"
     runs-on: ubuntu-latest
 
-    steps:
-      - name: "Add ${{ inputs.add_label }} label"
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ["${{ inputs.add_label }}"]
-            })
+    strategy:
+      matrix:
+        branch: ["cutting_release_branch/*", "prep-release/*"]
 
-      - name: "Remove ${{ inputs.remove_label }} label"
-        uses: actions/github-script@v6
+    steps:
+      - name: "Check out ${{ github.repository }}"
+        uses: actions/checkout@v3
         with:
-          script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: ["${{ inputs.remove_label }}"]
-            })
+          repository: ${{ github.repository }}
+
+      - name: "List Branch to be Deleted for: ${{ matrix.branch }}"
+        run: |
+          git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'
+
+      - name: "Delete Prerelease Branches: ${{ matrix.branch }}"
+        run: |
+          for b in $(git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'); do
+            git push origin --delete $b
+          done
+
+      - name: "[Sanity Check] List Branch matching: ${{ matrix.branch }}"
+        run: |
+          git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'
+
+  delete-draft-releases:
+    name: "Delete Draft Releases"
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: "List Draft Releases"
+        run: |
+          gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Delete Draft Releases in ${{ github.repository }}"
+        run: |
+          for release in $(gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'); do
+            echo "Deleting Draft Release: $release"
+            gh release --repo ${{ github.repository }} delete --yes $release
+          done
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: "[Sanity Check] List Draft Releases"
+        run: |
+          gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/swap-labels.yml
+++ b/.github/workflows/swap-labels.yml
@@ -30,6 +30,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
+          fetch-depth: 0
+      
+      - name: "Check status"
+        run: git status
 
       - name: "List Branch to be Deleted for: ${{ matrix.branch }}"
         run: |

--- a/.github/workflows/swap-labels.yml
+++ b/.github/workflows/swap-labels.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           repository: ${{ github.repository }}
           fetch-depth: 0
-      
-      - name: "Check status"
-        run: git status
 
       - name: "List Branch to be Deleted for: ${{ matrix.branch }}"
         run: |
@@ -45,12 +42,12 @@ jobs:
             git push origin --delete $b
           done
 
-      - name: "[Sanity Check] List Branch matching: ${{ matrix.branch }}"
+      - name: "[Expect None] List Branch matching: ${{ matrix.branch }}"
         run: |
           git branch -a --list "origin/${{ matrix.branch }}" | sed 's|.*remotes/origin/||'
 
   delete-draft-releases:
-    name: "Delete Draft Releases"
+    name: "Delete Draft Releases in ${{ github.repository }}"
     runs-on: ubuntu-latest
     steps:
       
@@ -69,7 +66,7 @@ jobs:
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: "[Sanity Check] List Draft Releases"
+      - name: "[Expect None] List Draft Releases"
         run: |
           gh release --repo ${{ github.repository }} list --limit 100 | awk -F '\t' '$2 == "Draft" {print $3}'
         env: 


### PR DESCRIPTION
resolves #78 

### Problem
Core + adapter repos are getting cluttered with draft releases and automation branches

### Solution
1. Delete branches matching the pattern `["cutting_release_branch/*", "prep-release/*"]`.
2. Delete releases in `Draft` status.

Every repo can make this decision for themselves but I plan to trigger this in core every Saturday.  This allows time to use the branches for debugging during the week.  If this workflow fails to run it is not something that will trigger a notification since it is simply for cleanup.