### PR TITLE
use latest stable macos runner for homebrew tests

### DIFF
--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -54,7 +54,7 @@ jobs:
           echo "name=$name" >> $GITHUB_OUTPUT
 
   homebrew-installation-test:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: generate-artifact-name
 
     steps:


### PR DESCRIPTION
Homebrew installation tests are timing out because `brew upgrade` takes almost six hours 
From homebrew logs:
> Warning: You are using macOS 11.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.