### PR TITLE
add private repos to excludes

### DIFF
--- a/.github/workflows/core-triage.yml
+++ b/.github/workflows/core-triage.yml
@@ -27,6 +27,11 @@ on:
       - .github/workflows/core-triage.yml
       - scripts/core-triage/**
 
+# will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   add-items-to-project:
     runs-on: ubuntu-latest
@@ -56,8 +61,8 @@ jobs:
         with:
           status: ${{ job.status }}
           notification_title: 'core-triage action failed'
-          message_format: ':x: Core Triage Project Automation ${{ steps.run-script.outputs.workflow-conclusion }}.  Needs attention but not an incident.'
-          footer: 'Linked failed run ${{ steps.run-script.outputs.workflow-url }}'
+          message_format: ':x: Core Triage Project Automation ${{ steps.run-script.outcome }}.  Needs attention but not an incident.'
+          footer: 'Linked failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
 

--- a/.github/workflows/core-triage.yml
+++ b/.github/workflows/core-triage.yml
@@ -31,33 +31,33 @@ jobs:
   add-items-to-project:
     runs-on: ubuntu-latest
     steps:
-      - name: check out repo
+      - name: "check out repo"
         uses: actions/checkout@v3
 
-      - name: setup python
+      - name: "setup python"
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
-      - name: pip installs
+      - name: "pip installs"
         run: pip install -r requirements.txt
         working-directory: scripts/core-triage
 
-      - name: run script
+      - name: "run script"
         id: run-script
         run: python project.py
         working-directory: scripts/core-triage
         env:
           GH_TOKEN: ${{ secrets.VARIABLE_CORE_TRIAGE_ONLY }}
 
-      - name: Post failure to core Slack
+      - name: "Post failure to core Slack channel"
         uses: ravsamhq/notify-slack-action@v2
         if: ${{ always() && steps.run-script.outcome != 'success' }}
         with:
           status: ${{ job.status }}
           notification_title: 'core-triage action failed'
-          message_format: ':x: Core Triage Project Automation ${{ steps.run-script.outputs.workflow-conclusion }}'
-          footer: 'Linked failed CI run ${{ steps.run-script.outputs.workflow-url }}'
+          message_format: ':x: Core Triage Project Automation ${{ steps.run-script.outputs.workflow-conclusion }}.  Needs attention but not an incident.'
+          footer: 'Linked failed run ${{ steps.run-script.outputs.workflow-url }}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
 

--- a/.github/workflows/core-triage.yml
+++ b/.github/workflows/core-triage.yml
@@ -44,7 +44,20 @@ jobs:
         working-directory: scripts/core-triage
 
       - name: run script
+        id: run-script
         run: python project.py
         working-directory: scripts/core-triage
         env:
           GH_TOKEN: ${{ secrets.VARIABLE_CORE_TRIAGE_ONLY }}
+
+      - name: Post failure to core Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: ${{ always() && steps.run-script.outcome != 'success' }}
+        with:
+          status: ${{ job.status }}
+          notification_title: 'core-triage action failed'
+          message_format: ':x: Core Triage Project Automation ${{ steps.run-script.outputs.workflow-conclusion }}'
+          footer: 'Linked failed CI run ${{ steps.run-script.outputs.workflow-url }}'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
+

--- a/scripts/core-triage/project.py
+++ b/scripts/core-triage/project.py
@@ -203,6 +203,16 @@ def main(
     # for each repo
     for repo in core_repos:
         print(f"Processing repository: {repo}...\n")
+        # private repos can't be connected.  Instead of bombing out, just skip them
+        try:
+            # TODO: add back label filtering
+            # get the list of PRs for the repo and label
+            prs = get_prs(repo, num_items)
+            # add PRs to the project
+            add_items_to_project(project_id, prs)
+        except:
+            print(f"Failed to connect to repo: {repo}...\n")
+            continue
         # for each issue label
         for issue_label in issue_labels:
             print(f"Processing issue label: {issue_label}...\n")
@@ -210,12 +220,6 @@ def main(
             issues = get_issues(repo, issue_label, num_items)
             # add issues to the project
             add_items_to_project(project_id, issues)
-
-        # TODO: add back label filtering
-        # get the list of PRs for the repo and label
-        prs = get_prs(repo, num_items)
-        # add PRs to the project
-        add_items_to_project(project_id, prs)
 
 
 # run script

--- a/scripts/core-triage/project.py
+++ b/scripts/core-triage/project.py
@@ -14,9 +14,9 @@ PROJECT_NUM = 22
 # core team name
 CORE_TEAM = "core-group"
 # repos determined by querying the team
-# exclude some repos (generally internal) that will cause failure
+# exclude some repos (generally internal/private) that will cause failure
 # include some extra repos not in the team
-EXCLUDE_REPOS = ["core-team", "schemas.getdbt.com"]
+EXCLUDE_REPOS = ["core-team", "schemas.getdbt.com", "clabot-config", "always-sunny"]
 EXTRA_REPOS = ["dbt-starter-project", "jaffle_shop", "dbt-server"]
 # issues added by label individually; lots of duplication here
 ISSUE_LABELS = [


### PR DESCRIPTION
resolves #143 

### Problem

The triage action has been failing for the past 2 months.  

Private/internal repos cause it to fail while processing.  New repos were added to the team but no added to the exclude.  This automation has only been partially working.

### Solution
- Remove internal/private repos as an exclude list and replace it with logic to always exclude private repos
- Send a notification when things do fail so it doesn't fail into the void