### PR TITLE
Update `core-triage` failure message to better convey low severity

### DIFF
--- a/.github/workflows/core-triage.yml
+++ b/.github/workflows/core-triage.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           status: ${{ job.status }}
           notification_title: 'core-triage action failed'
-          message_format: ':x: Core Triage Project Automation ${{ steps.run-script.outcome }}.  Needs attention but not an incident.'
+          message_format: ':x: Core Triage Project Automation ${{ steps.run-script.outcome }}.  Needs attention if it fails multiple times in a row, but this is not an incident.'
           footer: 'Linked failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}


### PR DESCRIPTION
resolves #149 

### Description

The failure message of the `core-triage` action has been updated to better convey the low severity of one-off failures

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue 
