### PR TITLE
Bump debian up to a supported version with Python >= 3.8

### DIFF
--- a/py-package-info/Dockerfile
+++ b/py-package-info/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install --target=/app setuptools
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/python3-debian10
+FROM gcr.io/distroless/python3-debian12
 COPY --from=builder /app /app
 WORKDIR /app
 ENV PYTHONPATH /app

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -38,7 +38,7 @@ class PackageInfo:
 
 
 def set_output(name, value):
-    os.system(f"""echo "{name}={value}" >> $GITHUB_OUTPUT""")
+    os.system(f"""echo "{name}={value}" >> "$GITHUB_OUTPUT" """)
 
 
 def get_exponential_backoff_in_seconds(attempt_number: int) -> int:

--- a/py-package-info/main.py
+++ b/py-package-info/main.py
@@ -38,7 +38,8 @@ class PackageInfo:
 
 
 def set_output(name, value):
-    os.system(f"""echo "{name}={value}" >> "$GITHUB_OUTPUT" """)
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        print(f'{name}={value}', file=fh)
 
 
 def get_exponential_backoff_in_seconds(attempt_number: int) -> int:


### PR DESCRIPTION
### Description

We were pinned to debian 10 which is out of support and used python 3.7 when we now need 3.8. The use of this image is dubious and should be revisited, but for now bump to debian 12.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue 
