### PR TITLE
Grant contents: read scope to determine team membership

### DIFF
--- a/.github/workflows/determine-team-membership.yml
+++ b/.github/workflows/determine-team-membership.yml
@@ -28,8 +28,8 @@ defaults:
   run:
     shell: bash
 
-# uses default permissions becuse the only permission it really needs is org:read which is set with the token
-# and not a permission that can be set at the workflow level
+permissions:
+  contents: read  #reads the team membership
 
 jobs:
   team-membership:

--- a/.github/workflows/label-community.yml
+++ b/.github/workflows/label-community.yml
@@ -31,6 +31,7 @@ defaults:
 
 permissions:
   pull-requests: write # labels PRs
+  contents: read # reads the team membership file
 
 jobs:
   determine-team-membership:


### PR DESCRIPTION

### Description

Got this error:
```
Run gh api -H "Accept: application/vnd.github+json" orgs/dbt-labs/teams/core/members > output_8394132721.json
  gh api -H "Accept: application/vnd.github+json" orgs/dbt-labs/teams/core/members > output_839413[2](https://github.com/dbt-labs/dbt-core/actions/runs/8394132721/job/22990577039?pr=9803#step:3:2)721.json
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GH_TOKEN: ***
gh: Not Found (HTTP [4](https://github.com/dbt-labs/dbt-core/actions/runs/8394132721/job/22990577039?pr=9803#step:3:4)04)
gh: This API operation needs the "repo" scope. To request it, run:  gh auth refresh -h github.com -s repo
Error: Process completed with exit code 1.
```

It's the same taken we use to release and do teh same operation so the token is not the issue.  There is no

```
permissions:
  repo: read
```

So using
```
permissions:
  contents: read
```

Instead because the docs say that's for the contents of the repo.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
