### PR TITLE
Create a unique artifact name for nightly installation tests

### DIFF
--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -53,8 +53,8 @@ jobs:
       - name: "Generate Artifact Name"
         id: artifact-name
         run: |
-          date=$(date +'%m%d%Y')
-          name="${{ env.ARTIFACT_BASENAME }}-$date"
+          date=$(date +'%m%d%Y-%H%M%S')
+          name="${{ env.ARTIFACT_BASENAME }}-${{ inputs.package_name }}-$date"
           echo "name=$name" >> $GITHUB_OUTPUT
 
   fetch-container-tags:

--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -115,7 +115,9 @@ jobs:
         with:
           registry: ${{ env.GITHUB_PACKAGES_LINK }}
           image: ${{ steps.image-info.outputs.ref }}
-          run: dbt --version
+          run: |
+            PACKAGE = $(echo ${{ inputs.package_name }} | cut -c 5-)
+            python -c "import dbt.adapters.$PACKAGE"
 
       - name: "Dump Job Status"
         if: ${{ always() }}

--- a/.github/workflows/test-dbt-installation-docker.yml
+++ b/.github/workflows/test-dbt-installation-docker.yml
@@ -123,7 +123,7 @@ jobs:
         if: ${{ always() }}
         id: job-status
         run: |
-          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-tag-${{ matrix.tag }}.json"
+          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-${{ matrix.tag }}.json"
           # Create file
           touch $file 
           # Write job status to file
@@ -137,7 +137,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}-${{ matrix.tag }}
           path: ${{ steps.job-status.outputs.path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -49,8 +49,8 @@ jobs:
       - name: "Generate Artifact Name"
         id: artifact-name
         run: |
-          date=$(date +'%m%d%Y')
-          name="${{ env.ARTIFACT_BASENAME }}-$date"
+          date=$(date +'%m%d%Y-%H%M%S')
+          name="${{ env.ARTIFACT_BASENAME }}-${{ inputs.package_name }}-$date"
           echo "name=$name" >> $GITHUB_OUTPUT
 
   homebrew-installation-test:

--- a/.github/workflows/test-dbt-installation-homebrew.yml
+++ b/.github/workflows/test-dbt-installation-homebrew.yml
@@ -85,7 +85,8 @@ jobs:
 
       - name: "Verify ${{ inputs.package_name }} Version"
         run: |
-          dbt --version
+          PACKAGE = $(echo ${{ inputs.package_name }} | cut -c 5-)
+          python -c "import dbt.adapters.$PACKAGE"
 
       - name: "Dump Job Status"
         if: ${{ always() }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ always() }}
         id: job-status
         run: |
-          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-python-v${{ matrix.python-version }}.json"
+          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-py${{ matrix.python-version }}.json"
           # Create file
           touch $file
           # Write job status to file
@@ -111,7 +111,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}-py${{ matrix.python-version }}
           path: ${{ steps.job-status.outputs.path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -90,7 +90,8 @@ jobs:
 
       - name: "Verify ${{ inputs.package_name }} Version"
         run: |
-          dbt --version
+          PACKAGE = $(echo ${{ inputs.package_name }} | cut -c 5-)
+          python -c "import dbt.adapters.$PACKAGE"
 
       - name: "Dump Job Status"
         if: ${{ always() }}

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -49,8 +49,8 @@ jobs:
       - name: "Generate Artifact Name"
         id: artifact-name
         run: |
-          date=$(date +'%m%d%Y')
-          name="${{ env.ARTIFACT_BASENAME }}-$date"
+          date=$(date +'%m%d%Y-%H%M%S')
+          name="${{ env.ARTIFACT_BASENAME }}-${{ inputs.package_name }}-$date"
           echo "name=$name" >> $GITHUB_OUTPUT
 
   pip-installation-test:

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ always() }}
         id: job-status
         run: |
-          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-branch-${{ matrix.branch }}-python-v${{ matrix.python-version }}.json"
+          file="test-${{ inputs.package_name }}-${{ strategy.job-index }}-${{ matrix.branch }}-py${{ matrix.python-version }}.json"
           # Create file
           touch $file
           # Write job status to file
@@ -157,7 +157,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}
+          name: ${{ needs.generate-artifact-name.outputs.artifact-name }}-${{ matrix.branch }}-py${{ matrix.python-version }}
           path: ${{ steps.job-status.outputs.path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -50,8 +50,8 @@ jobs:
       - name: "Generate Artifact Name"
         id: artifact-name
         run: |
-          date=$(date +'%m%d%Y')
-          name="${{ env.ARTIFACT_BASENAME }}-$date"
+          date=$(date +'%m%d%Y-%H%M%S')
+          name="${{ env.ARTIFACT_BASENAME }}-${{ inputs.package_name }}-$date"
           echo "name=$name" >> $GITHUB_OUTPUT
 
   fetch-latest-branches:

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -136,7 +136,8 @@ jobs:
 
       - name: "Verify ${{ inputs.package_name }} Version"
         run: |
-          dbt --version
+          PACKAGE = $(echo ${{ inputs.package_name }} | cut -c 5-)
+          python -c "import dbt.adapters.$PACKAGE"
 
       - name: "Dump Job Status"
         if: ${{ always() }}


### PR DESCRIPTION
### Description

Upload artifact requires a unique artifact name now, but we were just providing a name that was specific to the date. We failed the job status check for all but one package/method as a result. This adds the package name and a timestamp to the artifact name.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
