### PR TITLE
Retry `gh run watch` in `release-branch-tests` to avoid network errors

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -136,7 +136,7 @@ jobs:
         id: monitor-run
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 30
+          timeout_minutes: 180
           max_attempts: 3
           command: gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
         env:

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -134,8 +134,11 @@ jobs:
 
       - name: Wait for run to complete
         id: monitor-run
-        run: |
-          gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: gh run watch ${{ steps.workflow-id.outputs.id }} --interval 300 --exit-status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
resolves excessive alerting

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Retry GH watch action up to 3 times instead of erroring after the first failure.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development, and it appears to resolve the stated issue 
