### PR TITLE
Update dependabot to account for multiple directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@ updates:
     schedule:
       interval: "daily"
     rebase-strategy: "disabled"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/fetch-container-tags"
     schedule:
@@ -27,6 +22,11 @@ updates:
     rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/py-package-info"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,37 @@
 version: 2
 updates:
-  # python dependencies
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/scripts/core-triage"
     schedule:
       interval: "daily"
     rebase-strategy: "disabled"
-
-  # docker dependencies
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/fetch-container-tags"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"
-
-  # github dependencies
+  - package-ecosystem: "docker"
+    directory: "/fetch-repo-branches"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "docker"
+    directory: "/parse-semver"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "docker"
+    directory: "/py-package-info"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/test-dbt-installation-notification"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
     rebase-strategy: "disabled"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/fetch-container-tags"
     schedule:
@@ -22,16 +27,6 @@ updates:
     rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/py-package-info"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/workflows"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/test-dbt-installation-notification"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"


### PR DESCRIPTION
`dependabot` does not allow for multiple directories or recursion. Each directory requires an entry.