### PR TITLE
fix slack alerts

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Post failure to core Slack
         uses: ravsamhq/notify-slack-action@v2
-        if: ${{ always() && steps.monitor-run.outcome != 'success' && github.event.repository.name == 'dbt-core' }}
+        if: ${{ always() && steps.monitor-run.outcome != 'success' && (github.event.repository.name == 'dbt-core' || github.event.repository.name == 'dbt-common')}}
         with:
           status: ${{ job.status }}
           notification_title: '${{ github.event.repository.name }} scheduled run of "${{ matrix.branch }}" branch not successful'


### PR DESCRIPTION
resolves #171 

### Description

dbt-common is owned by the core team so the alerts need to be routed to the core team instead of falling into the adapters.  This was causing these alerts to silently fail since the adapters webhook wasn't passed in.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
