### PR TITLE
Add `github/release/edit` action

### DIFF
--- a/github/release/edit/action.yaml
+++ b/github/release/edit/action.yaml
@@ -1,0 +1,50 @@
+name: "Edit GitHub release"
+description: "Update a GitHub release with the provided attributes"
+
+inputs:
+    tag:
+        description: "The tag to publish (i.e. v1.0.0b1)"
+        required: true
+    is-draft:
+        description: "Indicates that this is a draft release"
+        default: ""
+
+runs:
+    using: composite
+    steps:
+    -   name: "[DEBUG] Inputs"
+        shell: bash
+        run: |
+            echo "==========INPUTS=========="
+            echo tag      : ${{ inputs.tag }}
+            echo is-draft : ${{ inputs.is-draft }}
+
+    -   name: "Set release inputs"
+        if: ${{ inputs.is-draft != '' }}
+        id: release
+        shell: bash
+        run: ./github/release/edit/set_release_inputs.sh
+        env:
+            IS_DRAFT: ${{ fromJSON(inputs.is-draft) }}
+
+    -   name: "Update `${{ inputs.tag }}`"
+        shell: bash
+        run: gh release edit $TAG --repo $REPO $DRAFT
+        env:
+            TAG: ${{ inputs.tag }}
+            REPO: "https://github.com/dbt-labs/${{ github.repository }}"
+            DRAFT: ${{ steps.release.outputs.draft }}
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    -   name: "[INFO] Edit GitHub release"
+        shell: bash
+        run: echo "::notice title=$TITLE::$MESSAGE"
+        env:
+            TITLE: "[${{ env.NOTIFICATION_PREFIX }}]: Edit GitHub release"
+            MESSAGE: "tag: `${{ inputs.tag }}`"
+
+    -   name: "[DEBUG] Outputs"
+        shell: bash
+        run: |
+            echo "==========OUTPUTS=========="
+            echo "N/A"

--- a/github/release/edit/set_release_inputs.sh
+++ b/github/release/edit/set_release_inputs.sh
@@ -1,0 +1,6 @@
+if $IS_DRAFT; then
+    draft="--draft=true"
+else
+    draft="--draft=false"
+fi
+echo "flag=$flag" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description

Edit a GitHub release. This currently only supports publishing a draft release as a non-draft release.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
