### PR TITLE
Add `github/team/view` action

### DIFF
--- a/github/team/view/action.yaml
+++ b/github/team/view/action.yaml
@@ -1,0 +1,36 @@
+name: "View GitHub team"
+description: "Get metadata about a GitHub team"
+
+inputs:
+    team:
+        description: "The name of the team"
+        required: true
+
+outputs:
+    members:
+        description: "A space delimited list of team members"
+        value: ${{ steps.team.outputs.members }}
+
+runs:
+    using: composite
+    steps:
+    -   name: "[DEBUG] Inputs"
+        shell: bash
+        run: |
+            echo "==========INPUTS=========="
+            echo team : ${{ inputs.team }}
+
+    -   name: "Get team metadata"
+        id: team
+        shell: bash
+        run: ./github/team/view/get_team_metadata.sh
+        env:
+            ENDPOINT: "orgs/dbt-labs/teams/${{ inputs.team }}/members"
+            HEADER: "Accept: application/vnd.github+json"
+            GH_TOKEN: ${{ secrets.IT_TEAM_MEMBERSHIP }}
+
+    -   name: "[DEBUG] Outputs"
+        shell: bash
+        run: |
+            echo "==========OUTPUTS=========="
+            echo members : ${{ steps.team.outputs.members }}

--- a/github/team/view/get_team_metadata.sh
+++ b/github/team/view/get_team_metadata.sh
@@ -1,0 +1,9 @@
+OUTPUT_FILE=output_$GITHUB_RUN_ID.json
+
+gh api $ENDPOINT -H "$HEADER" > $OUTPUT_FILE
+
+team_list=$(jq -r '.[].login' $OUTPUT_FILE)
+team_list_single=$(echo $team_list | tr '\n' ' ')
+echo "members=$team_list_single" >> $GITHUB_OUTPUT
+
+rm $OUTPUT_FILE


### PR DESCRIPTION
### Description

Get metadata about a GitHub team, e.g. its members.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
