### PR TITLE
Use PAT for checking for comment

### DIFF
--- a/.github/workflows/open-issue-in-repo.yml
+++ b/.github/workflows/open-issue-in-repo.yml
@@ -1,41 +1,17 @@
 # **what?**
 # Open an issue in a specified repository with a specified title and body.  If the issue already exists, do nothing.
-# The calling workflow should be triggered off an issue or PR.
 
 # **why?**
 # To be able to trigger issues to open in other repositories from a workflow in a different repository.
 
 # **when?**
 # This will be triggered from another workflow on an issue or PR.
-# This could also be triggered when a label is added to an issue or PR.
+# The calling workflow determines what trigger to use.
 
 
 name: Open Issue in Another Repository
 
 on:
-  workflow_dispatch:  # for testing
-    inputs:
-      issue_repository:
-        description: 'Repository to open the issue in'
-        required: true
-        type: string
-        default: dbt-labs/dbt-docs
-      issue_title:
-        description: 'Title of the issue'
-        required: true
-        type: string
-        default: "Testing issue opening from another workflow"
-      issue_body:
-        description: 'The body of the issue'
-        required: true
-        type: string
-        default: "This is a test issue opened from another workflow."
-      issue_number:
-        description: 'The issue to open the new issue from'
-        required: true
-        type: string
-        default: "133"
-
   workflow_call:
     inputs:
       issue_repository:
@@ -78,26 +54,20 @@ jobs:
           echo "inputs.issue_title:           ${{ inputs.issue_title}}"
           echo "inputs.issue_body:            ${{ inputs.issue_body }}"
 
-      # Even thought Github treats issues and PRs as teh same thing behind the scenes, the event context has us access
-      # them in different ways.  On workflow call we want to be able to differentiate between a workflow trigger by
-      # an issue and one trigger by a PR.
+      # Even though GitHub treats issues and PRs as the same thing behind the scenes, the event context accesses
+      # them in different ways.  Choose an issue number of PR number.  Only 1 will be filled.
       - name: "Determine Issue or PR Values"
         id: issue_values
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "issue_number=${{ inputs.issue_number }}" >> $GITHUB_OUTPUT
-          else
-            echo "issue_number=${{ github.event.pull_request.number || github.event.issue.number }}" >> $GITHUB_OUTPUT
-          fi
+          echo "issue_number=${{ github.event.pull_request.number || github.event.issue.number }}" >> $GITHUB_OUTPUT
       
-      # this step uses the read permission from the GITHUB_TOKEN it inherits
       - name: "Check for comment"
         uses: peter-evans/find-comment@v3
         id: issue_comment
         with:
           issue-number: ${{ steps.issue_values.outputs.issue_number }}
-          comment-author: "FishtownBuildBot"
           body-includes: "Opened a new issue in ${{ inputs.issue_repository }}:"
+          token: ${{ secrets.FISHTOWN_BOT_PAT }}
 
       - name: "Set if comment already exists"
         id: comment_check
@@ -109,7 +79,7 @@ jobs:
           else
             echo "exists=true" >> $GITHUB_OUTPUT
             title="Stop processing."
-            message="Comment already exists for this issue or PR indicating associated issue. New issue will not be opened."
+            message="Comment already exists for this issue or PR indicating an associated issue. New issue will not be opened."
           fi
           echo "::notice $title::$message"
 


### PR DESCRIPTION
resolves #

### Description

- Add PAT as token when checking for comment
- Remove comment author since it varies by PAT used
- Removed `workflow_dispatch` options since it will never work with the PAT need
- Cleans up some comments.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
