### PR TITLE
add input dir with default

### DIFF
--- a/.github/workflows/changelog-existence.yml
+++ b/.github/workflows/changelog-existence.yml
@@ -43,6 +43,11 @@ on:
         description: Label on the PR that indicates CHANGELOGs are not required.
         type: string
         required: true
+      changelog_directory:
+        description: The directory where the changelog files are stored.
+        type: string
+        required: true
+        default: 'unreleased'
 
 permissions:
   contents: read
@@ -74,7 +79,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
             exists:
-              - added|modified: '.changes/unreleased/**.yaml'
+              - added|modified: '.changes/${{ inputs.changelog_directory }}/**.yaml'
 
       # this step uses the read permission from the GITHUB_TOKEN it inherits
       - name: Check for comment


### PR DESCRIPTION
### Description

Make the directory to check for changelogs something that can be passed in.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
