### PR TITLE
we’ve dropped 3.8 so let’s remove it everywhere

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -68,7 +68,7 @@ permissions:
   contents: write
 
 env:
-  PYTHON_TARGET_VERSION: 3.8
+  PYTHON_TARGET_VERSION: 3.10
 
 jobs:
   prep_work:

--- a/.github/workflows/test-dbt-installation-pip.yml
+++ b/.github/workflows/test-dbt-installation-pip.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - name: "Set up Python - ${{ matrix.python-version }}"

--- a/.github/workflows/test-dbt-installation-source.yml
+++ b/.github/workflows/test-dbt-installation-source.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
         exclude:
           - branch: "1.0.latest"
             python-version: 3.9

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -39,7 +39,7 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: "Install spark dependencies"
         if: (( github.repository == 'dbt-labs/dbt-spark' ))


### PR DESCRIPTION
### Description

Stop running workflows with python 3.8

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
