### PR TITLE
modify the root of unreleased dir so it can be modified

### DIFF
--- a/.github/workflows/changelog-existence.yml
+++ b/.github/workflows/changelog-existence.yml
@@ -28,7 +28,7 @@
 #    with:
 #      changelog_comment: 'Thank you for your pull request! We could not find a changelog entry for this change. For details on how to document a change, see [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-changelog-entry).'
 #      skip_label: 'Skip Changelog'
-#      unreleased_dir: 'unreleased'
+#      unreleased_dir: '.changes/unreleased'
 #    secrets: inherit # this is only acceptable because we own the action we're calling
 #
 
@@ -49,7 +49,7 @@ on:
         description: The subdirectory unreleased changelogs are expected to be found. By default, this is 'unreleased'.
         type: string
         required: false
-        default: 'unreleased'
+        default: '.changes/unreleased'
 
 permissions:
   contents: read
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
             exists:
-              - added|modified: '.changes/${{ inputs.unreleased_dir }}/**.yaml'
+              - added|modified: '${{ inputs.unreleased_dir }}/**.yaml'
 
       # this step uses the read permission from the GITHUB_TOKEN it inherits
       - name: Check for comment


### PR DESCRIPTION
### Description

Support having changelogs exists within directories and not just at the root of the project by allowing the passed in unreleased-dir to be located somewhere other than `.changes`.  This also changes the default input to not break existing workflows.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/actions/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue 
