### PR TITLE
Declare IT_TEAM_MEMBERSHIP as named secret input

### DIFF
--- a/.github/workflows/determine-team-membership.yml
+++ b/.github/workflows/determine-team-membership.yml
@@ -19,6 +19,10 @@ on:
         type: string
         required: true
         default: 'core-group'
+    secrets:
+      IT_TEAM_MEMBERSHIP:
+        description: "Token that can view org level teams"
+        required: true
     outputs:
       membership_list:
         description: "Space delimited list of GitHub handles"

--- a/.github/workflows/label-community.yml
+++ b/.github/workflows/label-community.yml
@@ -1,5 +1,5 @@
 # **what?**
-# Will label a newly opened PR as a community cobtribution
+# Will label a newly opened PR or issue as a community contribution
 #
 # **why?**
 # To make triaging easier and faster
@@ -9,7 +9,7 @@
 
 ## Important: Your repository will need to be added to the included repositories for IT_TEAM_MEMBERSHIP
 
-name: Label Community PR
+name: Label Community Contribution
 
 on:
   workflow_call:
@@ -20,7 +20,7 @@ on:
         required: true
         default: 'core-group'
       label:
-        description: The label to add to the PR
+        description: The label to add
         type: string
         required: true
         default: 'community'
@@ -31,6 +31,7 @@ defaults:
 
 permissions:
   pull-requests: write # labels PRs
+  issues: write # labels issues
   contents: read # reads the team membership file
 
 jobs:
@@ -51,14 +52,15 @@ jobs:
         run: |
           echo ${{ inputs.github_team}} membership: ${{ needs.determine-team-membership.outputs.membership_list }}
       
-      - name: "Determine if Community PR"
+      - name: "Determine if Community Contribution"
         id: community
         run: |
-          if [[ " ${{ needs.determine-team-membership.outputs.membership_list }} " =~ " ${{ github.event.pull_request.user.login }} " ]]; then
-              echo "Author of the PR is in the list."
+          AUTHOR="${{ github.event.pull_request.user.login || github.event.issue.user.login }}"
+          if [[ " ${{ needs.determine-team-membership.outputs.membership_list }} " =~ " ${AUTHOR} " ]]; then
+              echo "Author is in the list."
               echo "category=internal" >> $GITHUB_OUTPUT
           else
-              echo "Author of the PR is not in the list."
+              echo "Author is not in the list."
               echo "category=external" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/label-community.yml
+++ b/.github/workflows/label-community.yml
@@ -24,6 +24,10 @@ on:
         type: string
         required: true
         default: 'community'
+    secrets:
+      IT_TEAM_MEMBERSHIP:
+        description: "Token that can view org level teams"
+        required: true
 
 defaults:
   run:
@@ -41,7 +45,8 @@ jobs:
     with:
       github_team: ${{ inputs.github_team }}
 
-    secrets: inherit
+    secrets:
+      IT_TEAM_MEMBERSHIP: ${{ secrets.IT_TEAM_MEMBERSHIP }}
 
   community_label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Declare `IT_TEAM_MEMBERSHIP` as a named secret input in `determine-team-membership.yml` and `label-community.yml`
- Replace `secrets: inherit` with explicit secret passing in `label-community.yml`
- This is backwards compatible — existing callers using `secrets: inherit` will continue to work

## Context
Follows least-privilege principle for workflows triggered by external events (`pull_request_target`, `issues`). Callers can now pass only the required secret instead of inheriting all repository secrets.

## Test plan
- [ ] Verify existing callers using `secrets: inherit` still work (backwards compatible)
- [ ] Verify callers can pass `IT_TEAM_MEMBERSHIP` explicitly
- [ ] Verify team membership lookup succeeds with explicit secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)