### PR TITLE
Add include_branches input to release-branch-tests

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -33,6 +33,10 @@ on:
         description: 'A list of branches to test. If provided, will override the release branches filtering'
         type: string
         default: ''
+      include_branches:
+        description: 'A list of additional branches to test alongside the default release branch filtering ex: ["my-feature-branch", "1.latest"]'
+        type: string
+        default: ''
 
 # no special access is needed
 permissions: read-all
@@ -48,6 +52,7 @@ jobs:
           echo "dry_run:             ${{ inputs.dry_run }}"
           echo "branch_override:     ${{ inputs.branch_override }}"
           echo "include_main:        ${{ inputs.include_main }}"
+          echo "include_branches:    ${{ inputs.include_branches }}"
 
   fetch-latest-branches:
     runs-on: ubuntu-latest
@@ -84,6 +89,7 @@ jobs:
         env:
           BRANCHES: ${{ steps.get-latest-branches.outputs.repo-branches }}
           INCLUDE_MAIN: ${{ inputs.include_main }}
+          INCLUDE_BRANCHES: ${{ inputs.include_branches }}
         run: |
           # Convert Python list syntax to JSON (single quotes to double quotes)
           branches_json=$(echo "$BRANCHES" | sed "s/'/\"/g")
@@ -97,10 +103,18 @@ jobs:
           branches=("1.7.latest" $last_two)
           if [ "$INCLUDE_MAIN" = "true" ]; then
             branches+=("main")
+          fi 
+
+          # Append any additional branches requested via include_branches
+          if [ -n "$INCLUDE_BRANCHES" ]; then
+            include_json=$(echo "$INCLUDE_BRANCHES" | sed "s/'/\"/g")
+            while IFS= read -r extra_branch; do
+              branches+=("$extra_branch")
+            done < <(echo "$include_json" | jq -r '.[]')
           fi
-          
-          # Convert to JSON array
-          json=$(printf '%s\n' "${branches[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          # Convert to JSON array (dedupe while preserving order)
+          json=$(printf '%s\n' "${branches[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0)) | reduce .[] as $b ([]; if index($b) then . else . + [$b] end)')
           echo "filtered-branches=$json" >> $GITHUB_OUTPUT
 
       - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -127,6 +127,9 @@ jobs:
           else
             branches="${{ steps.filter-branches.outputs.filtered-branches }}"
             message="The workflow will run tests in ${{ inputs.workflows_to_run }} for the following branches of the ${{ github.event.repository.name }} repo: $branches"
+            if [ "${{ inputs.include_branches }}" != "" ]; then
+              message="$message (including additional branches: ${{ inputs.include_branches }})"
+            fi
           fi
           
           if [ "${{ inputs.dry_run }}" == "true" ]; then


### PR DESCRIPTION
## What

Adds an optional `include_branches` input to the `release-branch-tests` reusable workflow. It lets callers append additional branches to the default release-branch filtering.

## How

- New `include_branches` string input (defaults to `''`), accepting a list in Python- or JSON-style syntax, e.g. `["my-feature-branch", "1.5.latest"]` — same format as `branch_override`.
- In the "Filter to 1.7.latest + last 2 + main" step, the extra branches are appended to the computed set, then the final array is deduped (order preserved) so a branch already present won't run twice.
- Added to the `[DEBUG] Print Inputs` step for visibility.

## Behavior notes

- Unlike `branch_override` (which **replaces** the default filtering), `include_branches` **augments** it. It only applies on the default path — when `branch_override` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)